### PR TITLE
fix: mobile hamburger menu visibility on landing page

### DIFF
--- a/components/landing/header.tsx
+++ b/components/landing/header.tsx
@@ -29,7 +29,7 @@ export function Header() {
   const mobileNavLinkClasses = "flex items-center gap-2 text-sm text-muted-foreground transition-all hover:bg-accent hover:text-accent-foreground hover:rounded-md px-2 py-1 -mx-2 -my-1"
 
   return (
-    <header className="h-12 border-b border-border/40 bg-background shadow-xl hover:shadow-2xl transition-all duration-300">
+    <header className="relative z-50 h-12 border-b border-border/40 bg-background shadow-xl hover:shadow-2xl transition-all duration-300">
       <div className="mx-auto flex h-12 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center gap-2">
           <div className="flex h-9 w-9 items-center justify-center rounded-lg overflow-hidden">
@@ -107,7 +107,7 @@ export function Header() {
       </div>
 
       {mobileMenuOpen && (
-        <div className="border-t border-border bg-background px-4 py-4 md:hidden">
+        <div className="absolute left-0 right-0 top-12 z-50 border-t border-border bg-background px-4 py-4 shadow-lg md:hidden">
           <nav className="flex flex-col gap-4">
             <div className="flex items-center justify-between pb-2">
               <span className="text-sm font-medium">Theme</span>
@@ -117,6 +117,7 @@ export function Header() {
             <Link
               href="#agents"
               className={navLinkClasses}
+              onClick={() => setMobileMenuOpen(false)}
             >
               <Users className="h-4 w-4" />
               Research Agents
@@ -139,6 +140,7 @@ export function Header() {
             <Link
               href="#prediction-markets"
               className={navLinkClasses}
+              onClick={() => setMobileMenuOpen(false)}
             >
               <TrendingUp className="h-4 w-4" />
               Events
@@ -146,6 +148,7 @@ export function Header() {
             <Link
               href="#copy-trading"
               className={navLinkClasses}
+              onClick={() => setMobileMenuOpen(false)}
             >
               <Sparkles className="h-4 w-4" />
               Copy Trade
@@ -153,6 +156,7 @@ export function Header() {
             <Link
               href="#strategies"
               className={navLinkClasses}
+              onClick={() => setMobileMenuOpen(false)}
             >
               <Target className="h-4 w-4" />
               Algo Bots
@@ -161,13 +165,14 @@ export function Header() {
             <Link
               href="/docs"
               className={navLinkClasses}
+              onClick={() => setMobileMenuOpen(false)}
             >
               <Sparkles className="h-4 w-4" />
               Docs
             </Link>
 
             <div className="pt-4">
-              <Link href="/login" className="block">
+              <Link href="/login" className="block" onClick={() => setMobileMenuOpen(false)}>
                 <button className="relative inline-flex h-12 w-full overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50">
                   <span className="absolute inset-[-1000%] animate-[spin_2s_linear_infinite] bg-[conic-gradient(from_90deg_at_50%_50%,#E2CBFF_0%,#393BB2_50%,#E2CBFF_100%)]" />
                   <span className="inline-flex h-full w-full cursor-pointer items-center justify-center rounded-full bg-green-600 dark:bg-green-700 px-3 py-1 text-sm font-medium text-white backdrop-blur-3xl space-x-2">


### PR DESCRIPTION
The dropdown was rendered in normal flow inside a fixed-height header without a stacking context, so the hero section (relative z-10) painted over it on mobile. Give the header relative z-50 and absolutely position the dropdown so it overlays subsequent sections, and dismiss the menu on link tap.