### PR TITLE
Make prediction markets section responsive on mobile devices

### DIFF
--- a/components/landing/prediction-markets-section.tsx
+++ b/components/landing/prediction-markets-section.tsx
@@ -209,7 +209,7 @@ export function PredictionMarketsSection() {
       <div className="container mx-auto px-4 max-w-7xl">
 
 
-        <div className="flex items-center justify-center gap-8 mb-16">
+        <div className="flex flex-col md:flex-row items-center justify-center gap-8 mb-16">
           <div className="text-center">
             <Badge variant="outline" className="mb-4 border-cyan-500/50 text-cyan-400">
               Prediction Markets Intelligence


### PR DESCRIPTION
## Summary
Updated the prediction markets section layout to be responsive across different screen sizes by implementing a mobile-first flex layout.

## Key Changes
- Modified the flex container to stack vertically on mobile devices and horizontally on medium screens and above
- Changed from `flex-row` (implicit default) to `flex flex-col md:flex-row` to ensure proper layout behavior on smaller viewports

## Implementation Details
The change uses Tailwind CSS responsive prefixes to conditionally apply layout styles:
- `flex-col`: Stacks items vertically on mobile (default)
- `md:flex-row`: Switches to horizontal layout on medium screens and larger

This ensures the prediction markets section content remains properly formatted and readable on all device sizes without requiring additional CSS or layout adjustments.

https://claude.ai/code/session_01XmBBCWnLPKLtaxBV8dhf9H