### PR TITLE
Redirect authenticated users to survey instead of dashboard

### DIFF
--- a/components/auth/google-signin.tsx
+++ b/components/auth/google-signin.tsx
@@ -21,14 +21,13 @@ export function GoogleSignIn() {
           const data = await response.json()
 
           if (data.hasCompletedSurvey) {
-            router.push("/dashboard")
+            router.push("/")
           } else {
             router.push("/survey")
           }
         } catch (error) {
           console.error("Error checking survey status:", error)
-          // Default to dashboard if check fails
-          router.push("/dashboard")
+          router.push("/survey")
         }
       }
     }
@@ -44,14 +43,14 @@ export function GoogleSignIn() {
     setIsLoading(true)
     await signIn.social({
       provider: "google",
-      callbackURL: "/dashboard",
+      callbackURL: "/survey",
     })
   }
 
   const handleDevLogin = async () => {
     setIsLoading(true)
     await signIn.anonymous({
-      callbackURL: "/dashboard",
+      callbackURL: "/survey",
     })
   }
 

--- a/components/auth/metamask-signin.tsx
+++ b/components/auth/metamask-signin.tsx
@@ -17,7 +17,10 @@ export function MetaMaskSignIn() {
 
   useEffect(() => {
     if (session?.user) {
-      router.push("/dashboard")
+      fetch('/api/user/check-survey')
+        .then(r => r.json())
+        .then(data => router.push(data.hasCompletedSurvey ? "/" : "/survey"))
+        .catch(() => router.push("/survey"))
     }
     if (typeof window !== "undefined") {
       setHasMetaMask(!!window.ethereum)
@@ -84,10 +87,15 @@ export function MetaMaskSignIn() {
         throw new Error(verifyError.message || "Verification failed")
       }
 
-      // Success - redirect to dashboard
       if (data) {
         router.refresh()
-        router.push("/dashboard")
+        try {
+          const surveyResponse = await fetch('/api/user/check-survey')
+          const surveyData = await surveyResponse.json()
+          router.push(surveyData.hasCompletedSurvey ? "/" : "/survey")
+        } catch {
+          router.push("/survey")
+        }
       }
 
     } catch (err) {

--- a/components/auth/siwe-signin.tsx
+++ b/components/auth/siwe-signin.tsx
@@ -86,14 +86,13 @@ export function SiweSignIn() {
           const surveyData = await surveyResponse.json()
 
           if (surveyData.hasCompletedSurvey) {
-            router.push("/dashboard")
+            router.push("/")
           } else {
             router.push("/survey")
           }
         } catch (error) {
           console.error("Error checking survey status:", error)
-          // Default to dashboard if check fails
-          router.push("/dashboard")
+          router.push("/survey")
         }
       }
 

--- a/components/investing/shared/investor-survey.tsx
+++ b/components/investing/shared/investor-survey.tsx
@@ -55,9 +55,9 @@ export default function InvestorSurvey() {
       // Scroll to top to show success message
       window.scrollTo({ top: 0, behavior: "smooth" })
 
-      // Redirect to dashboard after 2 seconds
+      // Redirect to homepage after 2 seconds
       setTimeout(() => {
-        router.push("/dashboard")
+        router.push("/")
       }, 2000)
 
   }


### PR DESCRIPTION
## Summary
This PR updates the authentication flow to redirect users to a survey page after login instead of directly to the dashboard. Users who have already completed the survey are redirected to the homepage, while new users are directed to complete the survey first.

## Key Changes
- **MetaMask Sign-In**: Updated post-login redirect to check survey completion status via `/api/user/check-survey` endpoint and route accordingly
- **Google Sign-In**: Changed default redirect from `/dashboard` to `/survey` for both OAuth and anonymous login flows; updated error fallback to redirect to survey instead of dashboard
- **SIWE Sign-In**: Updated post-login redirect to check survey completion status and route to homepage or survey based on completion status
- **Investor Survey**: Changed post-submission redirect from `/dashboard` to `/` (homepage)

## Implementation Details
- All authentication methods now call the `/api/user/check-survey` endpoint to determine the appropriate redirect destination
- Users with `hasCompletedSurvey: true` are redirected to `/` (homepage)
- Users with `hasCompletedSurvey: false` are redirected to `/survey`
- Error handling ensures users are redirected to `/survey` if the survey status check fails
- The survey completion check is performed both in `useEffect` hooks (on session establishment) and after successful authentication

https://claude.ai/code/session_01PnDEmJhXHjgiNnnKcS9pFC