### PR TITLE
Replace descriptive text with InfoTooltip components

### DIFF
--- a/components/landing/agents-section.tsx
+++ b/components/landing/agents-section.tsx
@@ -9,8 +9,9 @@ import {
   ShieldCheck,
   ArrowRight,
 } from "lucide-react"
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import Image from "next/image"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const analystTeam = [
   {
@@ -90,12 +91,10 @@ export function AgentsSection() {
                       <analyst.icon className="h-5 w-5 text-chart-1" />
                     </div>
                     <CardTitle className="text-sm text-foreground">{analyst.name}</CardTitle>
+                    <InfoTooltip iconClassName="h-3.5 w-3.5">{analyst.description}</InfoTooltip>
                   </div>
                 </CardHeader>
                 <CardContent>
-                  <CardDescription className="mb-3 text-xs text-muted-foreground">
-                    {analyst.description}
-                  </CardDescription>
                   <div className="flex flex-wrap gap-1">
                     {analyst.features.map((feature) => (
                       <span
@@ -124,10 +123,10 @@ export function AgentsSection() {
                     <team.icon className={`h-6 w-6 ${team.color}`} />
                   </div>
                   <CardTitle className="text-foreground">{team.name}</CardTitle>
+                  <InfoTooltip>{team.description}</InfoTooltip>
                 </div>
               </CardHeader>
               <CardContent>
-                <CardDescription className="mb-4 text-muted-foreground">{team.description}</CardDescription>
                 <div className="flex flex-wrap gap-2">
                   {team.features.map((feature) => (
                     <span

--- a/components/landing/architecture-section.tsx
+++ b/components/landing/architecture-section.tsx
@@ -1,5 +1,6 @@
 import { ArrowRight, ArrowDown } from "lucide-react"
 import Image from "next/image"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const workflow = [
   { name: "Analyst Team", desc: "4 specialized analysts gather data", color: "text-chart-1", border: "border-chart-1" },
@@ -32,12 +33,12 @@ export function ArchitectureSection() {
           </div>
           <div className="flex flex-col justify-center">
             <h3 className="text-2xl font-bold text-foreground">
-              Automation of Hedge Fund Level of Research
+              Hedge Fund Level Research, Automated{" "}
+              <InfoTooltip iconClassName="h-5 w-5">
+                Our AI agents analyze candlestick patterns, moving averages, and technical
+                indicators in real-time, providing institutional-grade market insights.
+              </InfoTooltip>
             </h3>
-            <p className="mt-4 text-muted-foreground">
-              Our AI agents analyze candlestick patterns, moving averages, and technical indicators in real-time,
-              providing institutional-grade market insights.
-            </p>
 
             <div className="mt-12 flex justify-center">
               <Image

--- a/components/landing/broker-platforms-section.tsx
+++ b/components/landing/broker-platforms-section.tsx
@@ -14,6 +14,7 @@ import {
   Wallet,
 } from "lucide-react";
 import Link from "next/link";
+import { InfoTooltip } from "@/components/landing/info-tooltip";
 
 export function BrokerPlatformsSection() {
   const brokers = [
@@ -164,22 +165,17 @@ export function BrokerPlatformsSection() {
                     </div>
                   </div>
 
-                  <broker.icon className={`h-6 w-6 text-primary opacity-50`} />
-                </div>
-
-                {/* Description */}
-                <p className="text-sm text-muted-foreground mb-3">
-                  {broker.description}
-                </p>
-
-                {/* Features */}
-                <div className="space-y-1.5 mb-3">
-                  {broker.features.map((feature, idx) => (
-                    <div key={idx} className="flex items-start gap-1.5">
-                      <CheckCircle className="h-3.5 w-3.5 text-primary mt-0.5 flex-shrink-0" />
-                      <span className="text-xs">{feature}</span>
-                    </div>
-                  ))}
+                  <div className="flex items-center gap-1.5">
+                    <InfoTooltip>
+                      <p className="mb-1.5">{broker.description}</p>
+                      <ul className="space-y-0.5">
+                        {broker.features.map((feature, idx) => (
+                          <li key={idx}>• {feature}</li>
+                        ))}
+                      </ul>
+                    </InfoTooltip>
+                    <broker.icon className={`h-6 w-6 text-primary opacity-50`} />
+                  </div>
                 </div>
 
                 {/* Assets */}

--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -24,6 +24,7 @@ import {
   LogIn,
 } from "lucide-react"
 import Link from "next/link"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const features = [
   { icon: Users, label: "Multi-Agent Teams" },
@@ -91,7 +92,12 @@ export function HeroSection() {
               transition={{ duration: 0.5, delay: 0.2 }}
               className="mt-6 max-w-md text-lg text-muted-foreground"
             >
-              AI agent teams research, debate, and execute trades across stocks and prediction markets.
+              AI agents research, debate, and trade for you.{" "}
+              <InfoTooltip>
+                Teams of specialized AI agents gather data, hold bull-vs-bear debates, and execute
+                trades across stocks and prediction markets — like a hedge fund research desk on
+                autopilot.
+              </InfoTooltip>
             </motion.p>
 
             <motion.div

--- a/components/landing/info-tooltip.tsx
+++ b/components/landing/info-tooltip.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { Info } from "lucide-react"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+export function InfoTooltip({
+  children,
+  className,
+  iconClassName,
+  label,
+}: {
+  children: React.ReactNode
+  className?: string
+  iconClassName?: string
+  label?: React.ReactNode
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label="More info"
+          className={cn(
+            "inline-flex shrink-0 align-middle text-muted-foreground/70 transition-colors hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-full",
+            className,
+          )}
+        >
+          {label ?? <Info className={cn("h-4 w-4", iconClassName)} />}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-xs text-left leading-relaxed">
+        {children}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/components/landing/market-correlations.tsx
+++ b/components/landing/market-correlations.tsx
@@ -17,6 +17,7 @@ import {
   AlertCircle,
   ArrowRight,
 } from "lucide-react"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const correlationCategories = [
   {
@@ -329,11 +330,14 @@ export function MarketCorrelations() {
         <Badge variant="outline" className="mb-4 border-violet-500/50 text-violet-400">
           Cross-Market Intelligence
         </Badge>
-        <h3 className="text-3xl font-bold mb-4">Stock Price Correlations with Event Prediction</h3>
-        <p className="text-muted-foreground max-w-3xl mx-auto">
-          Discover how prediction markets correlate with traditional securities across sectors. Our AI identifies
-          non-obvious relationships, providing 45-60 day advance signals for strategic positioning.
-        </p>
+        <h3 className="text-3xl font-bold mb-4">
+          Stock Price Correlations with Event Prediction{" "}
+          <InfoTooltip iconClassName="h-5 w-5">
+            Discover how prediction markets correlate with traditional securities across sectors.
+            Our AI identifies non-obvious relationships, providing 45-60 day advance signals for
+            strategic positioning.
+          </InfoTooltip>
+        </h3>
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
@@ -397,11 +401,11 @@ export function MarketCorrelations() {
                           </div>
                         </div>
                         <div className={`p-4 rounded-lg ${colors.bg} border ${colors.border}`}>
-                          <h4 className="text-sm font-semibold mb-2 flex items-center gap-2">
+                          <h4 className="text-sm font-semibold flex items-center gap-2">
                             <AlertCircle className="h-4 w-4" />
                             Trading Strategy
+                            <InfoTooltip>{correlation.strategy}</InfoTooltip>
                           </h4>
-                          <p className="text-sm text-muted-foreground">{correlation.strategy}</p>
                         </div>
                       </div>
                     </CardContent>
@@ -420,14 +424,18 @@ export function MarketCorrelations() {
               <AlertCircle className="w-6 h-6 text-violet-400" />
             </div>
             <div className="flex-1">
-              <h4 className="font-semibold mb-2">XGBoost & Prophet TimeSeries ML Models</h4>
-              <p className="text-sm text-muted-foreground mb-4">
-                Our platform combines 5-10 prediction market signals to forecast individual stock movements. The system
-                requires 3 validation criteria before generating high-conviction signals: elite forecaster consensus
-                (top 2% show &gt;65% agreement), cross-market confirmation (multiple related markets align), and
-                traditional indicator confluence (technical analysis and fundamentals support prediction market signal).
-                When all criteria meet thresholds, historical accuracy exceeds 70% over 3-6 month horizons.
-              </p>
+              <h4 className="font-semibold mb-4 flex items-center gap-2">
+                XGBoost & Prophet TimeSeries ML Models
+                <InfoTooltip>
+                  Our platform combines 5-10 prediction market signals to forecast individual stock
+                  movements. The system requires 3 validation criteria before generating
+                  high-conviction signals: elite forecaster consensus (top 2% show &gt;65%
+                  agreement), cross-market confirmation (multiple related markets align), and
+                  traditional indicator confluence (technical analysis and fundamentals support
+                  prediction market signal). When all criteria meet thresholds, historical accuracy
+                  exceeds 70% over 3-6 month horizons.
+                </InfoTooltip>
+              </h4>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div className="p-3 rounded-lg bg-background/50">
                   <p className="text-xs text-muted-foreground mb-1">Correlation Pairs Tracked</p>

--- a/components/landing/prediction-markets-section.tsx
+++ b/components/landing/prediction-markets-section.tsx
@@ -20,6 +20,7 @@ import {
 } from "lucide-react"
 import { MarketCorrelations } from "./market-correlations"
 import Image from "next/image"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const topTraders = [
 
@@ -216,8 +217,11 @@ export function PredictionMarketsSection() {
             </Badge>
             <h2 className="text-4xl md:text-5xl font-bold mb-4 text-balance">Polymarket & Kalshi Analysis</h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-pretty">
-              Research-based LLM analysis on prediction market outcomes with copy trading signals from top investors,
-              senators, and traders
+              LLM outcome analysis & copy trading signals{" "}
+              <InfoTooltip iconClassName="h-5 w-5">
+                Research-based LLM analysis on prediction market outcomes with copy trading
+                signals from top investors, senators, and traders.
+              </InfoTooltip>
             </p>
           </div>
           <Image
@@ -275,8 +279,10 @@ export function PredictionMarketsSection() {
                 <div className="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 w-fit mb-4">
                   <feature.icon className="w-5 h-5 text-cyan-400" />
                 </div>
-                <h3 className="font-semibold mb-2">{feature.title}</h3>
-                <p className="text-sm text-muted-foreground mb-3">{feature.description}</p>
+                <h3 className="font-semibold mb-2 flex items-center gap-1.5">
+                  {feature.title}
+                  <InfoTooltip>{feature.description}</InfoTooltip>
+                </h3>
                 <Badge variant="outline" className="text-xs border-emerald-500/30 text-emerald-400">
                   {feature.stats}
                 </Badge>
@@ -424,14 +430,15 @@ export function PredictionMarketsSection() {
                   <Brain className="w-6 h-6 text-cyan-400" />
                 </div>
                 <div className="flex-1">
-                  <h4 className="font-semibold mb-2 flex items-center gap-2">
+                  <h4 className="font-semibold mb-4 flex items-center gap-2">
                     LLM Outcome Analysis
                     <Badge className="bg-emerald-500/20 text-emerald-400 border-emerald-500/30">Live</Badge>
+                    <InfoTooltip>
+                      Our AI agents analyze prediction market data alongside news sentiment, social
+                      media trends, and historical patterns to identify high-probability outcomes
+                      and arbitrage opportunities.
+                    </InfoTooltip>
                   </h4>
-                  <p className="text-sm text-muted-foreground mb-4">
-                    Our AI agents analyze prediction market data alongside news sentiment, social media trends, and
-                    historical patterns to identify high-probability outcomes and arbitrage opportunities.
-                  </p>
                   <div className="grid sm:grid-cols-3 gap-4">
                     <div className="p-3 rounded-lg bg-background/50">
                       <p className="text-xs text-muted-foreground mb-1">Markets Analyzed</p>

--- a/components/landing/signal-indicators.tsx
+++ b/components/landing/signal-indicators.tsx
@@ -11,6 +11,7 @@ import {
   DollarSign,
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const apiDataSources = [
   {
@@ -86,10 +87,12 @@ export function SignalIndicators() {
                     {source.category}
                   </Badge>
                 </div>
-                <h3 className="font-semibold text-foreground">{source.name}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">{source.description}</p>
+                <h3 className="font-semibold text-foreground flex items-center gap-1.5">
+                  {source.name}
+                  <InfoTooltip>{source.description}</InfoTooltip>
+                </h3>
                 <div className="mt-4 flex flex-wrap gap-1.5">
-                  {source.endpoints.slice(0, 5).map((endpoint) => (
+                  {source.endpoints.slice(0, 3).map((endpoint) => (
                     <span
                       key={endpoint}
                       className="rounded-md bg-secondary px-2 py-1 text-xs font-medium text-muted-foreground"
@@ -97,10 +100,13 @@ export function SignalIndicators() {
                       {endpoint}
                     </span>
                   ))}
-                  {source.endpoints.length > 5 && (
-                    <span className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary">
-                      +{source.endpoints.length - 5} more
-                    </span>
+                  {source.endpoints.length > 3 && (
+                    <InfoTooltip
+                      className="rounded-md bg-primary/10 px-2 py-1 text-xs font-medium text-primary hover:text-primary"
+                      label={`+${source.endpoints.length - 3} more`}
+                    >
+                      {source.endpoints.slice(3).join(" · ")}
+                    </InfoTooltip>
                   )}
                 </div>
               </div>

--- a/components/landing/strategies-section.tsx
+++ b/components/landing/strategies-section.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { TrendingUp, ArrowLeftRight, Zap, Timer, ChevronRight, Check, X } from "lucide-react"
 import { cn } from "@/lib/utils"
 import Image from "next/image"
+import { InfoTooltip } from "@/components/landing/info-tooltip"
 
 const tradingViewStrategies = [
   "RSI-Adaptive T3 & SAR Strategy",
@@ -189,13 +190,14 @@ export function StrategiesSection() {
         <div className="mb-16 flex flex-col items-center gap-8 lg:flex-row lg:items-start lg:gap-12">
           <div className="flex-1 text-center lg:text-left">
             <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
-              Algorithmic Trading Strategies
+              Algorithmic Trading Strategies{" "}
+              <InfoTooltip iconClassName="h-5 w-5">
+                Four AI-powered algorithmic strategies leveraging technical indicators (MACD, RSI,
+                Bollinger Bands, ATR) for different market conditions. Each strategy is powered by
+                our multi-agent system analyzing chart patterns, volume signals, and momentum
+                indicators with precision timing.
+              </InfoTooltip>
             </h2>
-            <p className="mt-4 max-w-2xl text-muted-foreground">
-              Four AI-powered algorithmic strategies leveraging technical indicators (MACD, RSI, Bollinger Bands, ATR)
-              for different market conditions. Each strategy is powered by our multi-agent system analyzing chart patterns,
-              volume signals, and momentum indicators with precision timing.
-            </p>
           </div>
           <div className="relative h-48 w-full max-w-xs overflow-hidden rounded-xl border border-border lg:h-56 lg:max-w-md">
             <Image
@@ -213,10 +215,13 @@ export function StrategiesSection() {
         <div className="mb-12 rounded-2xl border border-purple-500/30 bg-purple-500/5 p-6 lg:p-8">
           <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <h3 className="text-xl font-bold text-foreground">Select Strategies to Backtest</h3>
-              <p className="mt-1 text-sm text-muted-foreground">
-                Choose from TradingView expert algorithms - like having a personal hedge fund team
-              </p>
+              <h3 className="text-xl font-bold text-foreground flex items-center gap-2">
+                Select Strategies to Backtest
+                <InfoTooltip>
+                  Choose from TradingView expert algorithms — like having a personal hedge fund
+                  team.
+                </InfoTooltip>
+              </h3>
             </div>
             <div className="flex items-center gap-2 text-purple-400">
               <Zap className="h-5 w-5" />


### PR DESCRIPTION
## Summary
Refactored multiple landing page sections to use a new `InfoTooltip` component instead of displaying descriptive text inline. This improves UI density and visual hierarchy by moving supplementary information into tooltips while keeping primary content concise.

## Key Changes
- **Created new `InfoTooltip` component** (`components/landing/info-tooltip.tsx`): A reusable tooltip wrapper that displays an info icon with customizable styling and tooltip content
- **Updated Market Correlations section**: Moved section description and strategy details into tooltips; removed redundant paragraph text
- **Updated Prediction Markets section**: Converted feature descriptions and LLM analysis details to tooltip format
- **Updated Strategies section**: Moved algorithmic strategy explanation into tooltip; removed descriptive paragraph
- **Updated Signal Indicators section**: Converted data source descriptions to tooltips; refactored endpoint display to show 3 items with remaining endpoints in a tooltip
- **Updated Architecture section**: Moved research automation description into tooltip
- **Updated Agents section**: Converted analyst and team descriptions to tooltips; removed CardDescription elements
- **Updated Broker Platforms section**: Consolidated broker descriptions and features into a single tooltip
- **Updated Hero section**: Condensed tagline and moved detailed explanation into tooltip

## Implementation Details
- `InfoTooltip` component uses Radix UI's Tooltip primitives with consistent styling (muted foreground color, hover effects, focus ring)
- Supports customizable icon size via `iconClassName` prop and custom label via `label` prop
- Maintains accessibility with proper ARIA labels and keyboard navigation
- Tooltip content has max-width constraint and improved text formatting for readability
- Changes preserve all original information while improving visual presentation

https://claude.ai/code/session_01Jkrm7ZxWrcPoJFk6hB8wrz