### PR TITLE
Add hero effects across homepage, auto-scroll broker row, 900px column

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -184,6 +184,30 @@
   }
 }
 
+@keyframes hero-shimmer {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes hero-glow-pulse {
+  0%,
+  100% {
+    opacity: 0.4;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.9;
+    transform: scale(1.06);
+  }
+}
+
 @layer utilities {
   .animate-marquee {
     animation: marquee var(--duration, 40s) linear infinite;
@@ -199,6 +223,15 @@
 
   .animate-hero-orb {
     animation: hero-orb 10s ease-in-out infinite;
+  }
+
+  .animate-hero-shimmer {
+    background-size: 200% auto;
+    animation: hero-shimmer 5s ease-in-out infinite;
+  }
+
+  .animate-hero-glow-pulse {
+    animation: hero-glow-pulse 7s ease-in-out infinite;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera */

--- a/components/landing/agents-section.tsx
+++ b/components/landing/agents-section.tsx
@@ -78,13 +78,20 @@ const otherTeams = [
 
 export function AgentsSection() {
   return (
-    <section id="agents" className="overflow-hidden">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+    <section id="agents" className="relative overflow-hidden">
+      {/* Ambient hero-style glow orbs */}
+      <div className="pointer-events-none absolute top-10 -right-24 h-80 w-80 rounded-full bg-violet-500/10 blur-3xl animate-hero-orb" />
+      <div className="pointer-events-none absolute bottom-0 -left-24 h-72 w-72 rounded-full bg-emerald-500/10 blur-3xl animate-hero-orb [animation-delay:-3s]" />
+
+      <div className="relative mx-auto max-w-[900px] px-4 sm:px-6 lg:px-8">
         {/* Analyst Team */}
         <div className="">
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="grid gap-4 sm:grid-cols-2">
             {analystTeam.map((analyst) => (
-              <Card key={analyst.name} className="border-border bg-card">
+              <Card
+                key={analyst.name}
+                className="border-border bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5"
+              >
                 <CardHeader className="pb-2">
                   <div className="flex items-center gap-3">
                     <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-chart-1/10">
@@ -115,7 +122,10 @@ export function AgentsSection() {
         {/* Other Teams */}
         <div className="mt-6 grid gap-6 lg:grid-cols-2">
           {otherTeams.map((team) => (
-            <Card key={team.name} className="relative overflow-hidden border-border bg-card">
+            <Card
+              key={team.name}
+              className="relative overflow-hidden border-border bg-card/80 backdrop-blur-sm transition-all duration-300 hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5"
+            >
               <div className={`absolute right-0 top-0 h-32 w-32 ${team.bg} blur-3xl`} />
               <CardHeader>
                 <div className="flex items-center gap-4">

--- a/components/landing/architecture-section.tsx
+++ b/components/landing/architecture-section.tsx
@@ -17,8 +17,12 @@ const workflow = [
 
 export function ArchitectureSection() {
   return (
-    <section id="workflow" className="m-10 px-4 sm:px-6 lg:px-8 overflow-hidden">
-      <div className="mx-auto max-w-7xl">
+    <section id="workflow" className="relative my-10 px-4 sm:px-6 lg:px-8 overflow-hidden">
+      {/* Ambient hero-style glow orbs */}
+      <div className="pointer-events-none absolute -top-20 -left-20 h-80 w-80 rounded-full bg-emerald-500/10 blur-3xl animate-hero-orb" />
+      <div className="pointer-events-none absolute -bottom-24 -right-16 h-72 w-72 rounded-full bg-teal-500/10 blur-3xl animate-hero-orb [animation-delay:-6s]" />
+
+      <div className="relative mx-auto max-w-[900px]">
         <div className="grid gap-8 lg:grid-cols-2">
           <div className="relative flex items-center justify-center overflow-hidden rounded-2xl ">
 
@@ -32,7 +36,7 @@ export function ArchitectureSection() {
             />
           </div>
           <div className="flex flex-col justify-center">
-            <h3 className="text-2xl font-bold text-foreground">
+            <h3 className="text-2xl font-bold bg-gradient-to-r from-foreground via-foreground to-emerald-400 bg-clip-text text-transparent animate-hero-shimmer">
               Hedge Fund Level Research, Automated{" "}
               <InfoTooltip iconClassName="h-5 w-5">
                 Our AI agents analyze candlestick patterns, moving averages, and technical

--- a/components/landing/broker-platforms-section.tsx
+++ b/components/landing/broker-platforms-section.tsx
@@ -15,6 +15,8 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { InfoTooltip } from "@/components/landing/info-tooltip";
+import { Marquee } from "@/components/ui/marquee";
+import { BorderBeam } from "@/components/ui/border-beam";
 
 export function BrokerPlatformsSection() {
   const brokers = [
@@ -105,20 +107,29 @@ export function BrokerPlatformsSection() {
     },
   ];
   return (
-    <section className="relative sm:px-6 lg:px-8 bg-muted/30">
-      <div className="mx-auto max-w-7xl">
+    <section className="relative overflow-hidden px-4 sm:px-6 lg:px-8 bg-muted/30">
+      {/* Ambient hero-style glow orbs */}
+      <div className="pointer-events-none absolute -top-24 left-1/4 h-72 w-72 rounded-full bg-emerald-500/10 blur-3xl animate-hero-orb" />
+      <div className="pointer-events-none absolute -bottom-24 right-1/4 h-72 w-72 rounded-full bg-violet-500/10 blur-3xl animate-hero-orb [animation-delay:-4s]" />
+
+      <div className="relative mx-auto max-w-[900px]">
         {/* Flow Arrow */}
         <div className="my-8 flex justify-center">
-          <div className="flex items-center gap-2 rounded-full border border-border bg-card px-4 py-2">
-            <span className="text-sm text-muted-foreground">
+          <div className="relative flex items-center gap-2 overflow-hidden rounded-full border border-primary/30 bg-card/80 px-4 py-2 shadow-lg backdrop-blur-sm">
+            <span className="h-2 w-2 rounded-full bg-primary animate-pulse" />
+            <span className="text-sm font-medium bg-gradient-to-r from-primary via-emerald-400 to-teal-400 bg-clip-text text-transparent animate-hero-shimmer">
               Order flow to auto trade on
             </span>
             <ArrowRight className="h-4 w-4 text-primary" />
+            <BorderBeam size={36} duration={5} />
           </div>
         </div>
 
-        {/* Broker Cards Grid */}
-        <div className="flex gap-4 overflow-x-auto pb-4 mb-12 custom-scrollbar">
+        {/* Broker Cards — auto-scrolling, no scrollbar */}
+        <Marquee
+          pauseOnHover
+          className="mb-12 [--duration:35s] [--gap:1rem] [mask-image:linear-gradient(to_right,transparent,black_8%,black_92%,transparent)]"
+        >
           {brokers.map((broker) => (
             <Card
               key={broker.name}
@@ -204,9 +215,13 @@ export function BrokerPlatformsSection() {
                   )}
                 </Button> */}
               </div>
+
+              {broker.status === "Active" && (
+                <BorderBeam size={50} duration={8} colorFrom="#34d399" colorTo="#14b8a6" />
+              )}
             </Card>
           ))}
-        </div>
+        </Marquee>
       </div>
     </section>
   );

--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -61,10 +61,10 @@ export function HeroSection() {
       <div className="pointer-events-none absolute -top-32 -left-32 h-96 w-96 rounded-full bg-emerald-500/20 blur-3xl animate-hero-orb" />
       <div className="pointer-events-none absolute -bottom-40 -right-24 h-[28rem] w-[28rem] rounded-full bg-violet-500/15 blur-3xl animate-hero-orb [animation-delay:-5s]" />
 
-      <div className="mx-auto max-w-7xl px-6 pt-16 pb-8 lg:px-8 relative z-10 min-h-[85vh] flex flex-col justify-center">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          {/* Left: copy + CTAs */}
-          <div className="flex flex-col items-center lg:items-start text-center lg:text-left">
+      <div className="mx-auto max-w-[900px] px-6 pt-16 pb-8 lg:px-8 relative z-10 min-h-[85vh] flex flex-col justify-center">
+        <div className="flex flex-col gap-12 items-center">
+          {/* Copy + CTAs */}
+          <div className="flex flex-col items-center text-center">
             <motion.div
               {...fadeUp}
               transition={{ duration: 0.5 }}
@@ -82,7 +82,7 @@ export function HeroSection() {
               <span className="block bg-gradient-to-br from-foreground via-foreground to-foreground/40 bg-clip-text text-transparent">
                 Vibe-Trade Like a Boss
               </span>
-              <span className="block bg-gradient-to-r from-primary via-emerald-400 to-teal-400 bg-clip-text text-transparent">
+              <span className="block bg-gradient-to-r from-primary via-emerald-400 to-teal-400 bg-clip-text text-transparent animate-hero-shimmer">
                 Auto-Invest Like a Hedge Fund
               </span>
             </motion.h1>
@@ -103,7 +103,7 @@ export function HeroSection() {
             <motion.div
               {...fadeUp}
               transition={{ duration: 0.5, delay: 0.3 }}
-              className="mt-8 flex flex-wrap items-center justify-center lg:justify-start gap-4"
+              className="mt-8 flex flex-wrap items-center justify-center gap-4"
             >
               <Link href="/login" rel="noopener noreferrer">
                 <button className="relative inline-flex h-12 overflow-hidden rounded-full p-[1px] focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-background">
@@ -126,7 +126,7 @@ export function HeroSection() {
             <motion.div
               {...fadeUp}
               transition={{ duration: 0.5, delay: 0.4 }}
-              className="mt-6 flex flex-wrap items-center justify-center lg:justify-start gap-5"
+              className="mt-6 flex flex-wrap items-center justify-center gap-5"
             >
               <Link href="https://play.google.com/store/apps/details?id=com.autoinvestment.broker.app" target="_blank" rel="noopener noreferrer">
                 <Image
@@ -160,13 +160,14 @@ export function HeroSection() {
             </motion.div>
           </div>
 
-          {/* Right: video + floating graphics */}
+          {/* Video + floating graphics */}
           <motion.div
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ duration: 0.6, delay: 0.2 }}
-            className="relative"
+            className="relative w-full"
           >
+            <div className="pointer-events-none absolute -inset-8 rounded-[2rem] bg-gradient-to-r from-emerald-500/15 via-teal-500/10 to-violet-500/15 blur-2xl animate-hero-glow-pulse" />
             <div className="relative rounded-2xl overflow-hidden shadow-2xl border border-border/50 bg-background/50 backdrop-blur-sm aspect-video">
               <iframe
                 className="absolute inset-0 w-full h-full"

--- a/components/landing/prediction-markets-section.tsx
+++ b/components/landing/prediction-markets-section.tsx
@@ -21,6 +21,7 @@ import {
 import { MarketCorrelations } from "./market-correlations"
 import Image from "next/image"
 import { InfoTooltip } from "@/components/landing/info-tooltip"
+import { BorderBeam } from "@/components/ui/border-beam"
 
 const topTraders = [
 
@@ -206,8 +207,12 @@ export function PredictionMarketsSection() {
   const [selectedTrader, setSelectedTrader] = useState<string | null>(null)
 
   return (
-    <section id="prediction-markets" className="py-24 bg-muted/30 overflow-hidden">
-      <div className="container mx-auto px-4 max-w-7xl">
+    <section id="prediction-markets" className="relative py-24 bg-muted/30 overflow-hidden">
+      {/* Ambient hero-style glow orbs */}
+      <div className="pointer-events-none absolute -top-24 -left-24 h-96 w-96 rounded-full bg-cyan-500/10 blur-3xl animate-hero-orb" />
+      <div className="pointer-events-none absolute -bottom-32 -right-24 h-96 w-96 rounded-full bg-emerald-500/10 blur-3xl animate-hero-orb [animation-delay:-5s]" />
+
+      <div className="relative container mx-auto px-4 max-w-[900px]">
 
 
         <div className="flex flex-col md:flex-row items-center justify-center gap-8 mb-16">
@@ -215,7 +220,9 @@ export function PredictionMarketsSection() {
             <Badge variant="outline" className="mb-4 border-cyan-500/50 text-cyan-400">
               Prediction Markets Intelligence
             </Badge>
-            <h2 className="text-4xl md:text-5xl font-bold mb-4 text-balance">Polymarket & Kalshi Analysis</h2>
+            <h2 className="text-4xl md:text-5xl font-bold mb-4 text-balance bg-gradient-to-r from-foreground via-cyan-400 to-foreground bg-clip-text text-transparent animate-hero-shimmer">
+              Polymarket & Kalshi Analysis
+            </h2>
             <p className="text-xl text-muted-foreground max-w-3xl mx-auto text-pretty">
               LLM outcome analysis & copy trading signals{" "}
               <InfoTooltip iconClassName="h-5 w-5">
@@ -294,7 +301,8 @@ export function PredictionMarketsSection() {
 
 
         {/* Copy Trading Leaderboard */}
-        <Card className="bg-card/50 border-border/50 backdrop-blur max-w-4xl mx-auto">
+        <Card className="relative overflow-hidden bg-card/50 border-border/50 backdrop-blur max-w-4xl mx-auto">
+          <BorderBeam size={100} duration={10} colorFrom="#22d3ee" colorTo="#34d399" />
           <CardHeader>
 
 

--- a/components/landing/signal-indicators.tsx
+++ b/components/landing/signal-indicators.tsx
@@ -66,8 +66,12 @@ const apiDataSources = [
 
 export function SignalIndicators() {
   return (
-    <section id="signals" className=" px-4  sm:px-6 lg:px-8">
-      <div className="mx-auto max-w-7xl">
+    <section id="signals" className="relative overflow-hidden px-4 sm:px-6 lg:px-8">
+      {/* Ambient hero-style glow orbs */}
+      <div className="pointer-events-none absolute -top-16 left-1/3 h-72 w-72 rounded-full bg-teal-500/10 blur-3xl animate-hero-orb" />
+      <div className="pointer-events-none absolute bottom-0 -right-20 h-80 w-80 rounded-full bg-emerald-500/10 blur-3xl animate-hero-orb [animation-delay:-5s]" />
+
+      <div className="relative mx-auto max-w-[900px]">
 
 
         <div className="mt-4">
@@ -77,7 +81,7 @@ export function SignalIndicators() {
             {apiDataSources.map((source) => (
               <div
                 key={source.name}
-                className="group rounded-xl border border-border bg-card p-6 transition-all hover:border-primary/40"
+                className="group rounded-xl border border-border bg-card/80 p-6 backdrop-blur-sm transition-all duration-300 hover:border-primary/40 hover:shadow-lg hover:shadow-primary/5 hover:-translate-y-0.5"
               >
                 <div className="mb-4 flex items-center justify-between">
                   <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary/10 transition-colors group-hover:bg-primary/20">

--- a/components/landing/strategies-section.tsx
+++ b/components/landing/strategies-section.tsx
@@ -5,6 +5,7 @@ import { TrendingUp, ArrowLeftRight, Zap, Timer, ChevronRight, Check, X } from "
 import { cn } from "@/lib/utils"
 import Image from "next/image"
 import { InfoTooltip } from "@/components/landing/info-tooltip"
+import { BorderBeam } from "@/components/ui/border-beam"
 
 const tradingViewStrategies = [
   "RSI-Adaptive T3 & SAR Strategy",
@@ -185,11 +186,15 @@ export function StrategiesSection() {
   const colors = colorVariants[activeStrategy.color as keyof typeof colorVariants]
 
   return (
-    <section id="strategies" className="border-t border-border px-4 py-24 sm:px-6 lg:px-8 overflow-hidden">
-      <div className="mx-auto max-w-7xl">
+    <section id="strategies" className="relative border-t border-border px-4 py-24 sm:px-6 lg:px-8 overflow-hidden">
+      {/* Ambient hero-style glow orbs */}
+      <div className="pointer-events-none absolute -top-20 right-1/4 h-80 w-80 rounded-full bg-purple-500/10 blur-3xl animate-hero-orb" />
+      <div className="pointer-events-none absolute -bottom-24 -left-20 h-72 w-72 rounded-full bg-emerald-500/10 blur-3xl animate-hero-orb [animation-delay:-7s]" />
+
+      <div className="relative mx-auto max-w-[900px]">
         <div className="mb-16 flex flex-col items-center gap-8 lg:flex-row lg:items-start lg:gap-12">
           <div className="flex-1 text-center lg:text-left">
-            <h2 className="text-3xl font-bold tracking-tight text-foreground sm:text-4xl">
+            <h2 className="text-3xl font-bold tracking-tight sm:text-4xl bg-gradient-to-r from-foreground via-purple-400 to-foreground bg-clip-text text-transparent animate-hero-shimmer">
               Algorithmic Trading Strategies{" "}
               <InfoTooltip iconClassName="h-5 w-5">
                 Four AI-powered algorithmic strategies leveraging technical indicators (MACD, RSI,
@@ -212,7 +217,8 @@ export function StrategiesSection() {
         </div>
 
         {/* TradingView Expert Strategies Card */}
-        <div className="mb-12 rounded-2xl border border-purple-500/30 bg-purple-500/5 p-6 lg:p-8">
+        <div className="relative mb-12 overflow-hidden rounded-2xl border border-purple-500/30 bg-purple-500/5 p-6 lg:p-8 backdrop-blur-sm">
+          <BorderBeam size={90} duration={9} colorFrom="#a855f7" colorTo="#34d399" />
           <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h3 className="text-xl font-bold text-foreground flex items-center gap-2">


### PR DESCRIPTION
- Broker "Order flow to auto trade on" row now auto-scrolls via Marquee with edge fade masks instead of a scrollable row with a scrollbar
- Add shimmer gradient headings, glow-pulse video halo, BorderBeam accents, and ambient animated orbs to landing sections
- Constrain all homepage sections to a centered 900px max-width column with side margins; hero stacks into a single centered column


Claude-Session: https://claude.ai/code/session_01JY1oynzGm3LMh11PQmos4P