### PR TITLE
Update research paper link from Google Drive to Zenodo

### DIFF
--- a/components/landing/hero-section.tsx
+++ b/components/landing/hero-section.tsx
@@ -148,7 +148,7 @@ export function HeroSection() {
                 <ArrowUpRight className="h-3 w-3" />
               </Link>
               <Link
-                href="https://drive.google.com/file/d/1QJqoy3on4Q34djAM2DgMW7udBRfSHuMg/view?usp=drive_link"
+                href="https://zenodo.org/records/20836179"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"


### PR DESCRIPTION
## Summary
Updated the research paper link in the hero section from a Google Drive URL to a Zenodo repository link.

## Changes
- Replaced Google Drive link (`https://drive.google.com/file/d/1QJqoy3on4Q34djAM2DgMW7udBRfSHuMg/view?usp=drive_link`) with Zenodo link (`https://zenodo.org/records/20836179`) in the hero section component

## Details
This change directs users to the persistent Zenodo repository for the research paper instead of a temporary Google Drive link, providing better long-term accessibility and archival of the research material.

https://claude.ai/code/session_01Hw4HS36HAbfcmfC57uyY24