### PR TITLE
Restore homepage research diagram and convert landing sections to theme-aware backgrounds

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,8 +24,9 @@ export default function LandingPage() {
         description="Give your AI agent a dedicated brokerage account. It researches, debates competing theses, then places trades — you monitor performance in one calm dashboard."
         ctaLabel="Meet the agents"
         ctaHref="/debate"
-        imageSrc="/images/landing/feature-agent.jpg"
-        imageAlt="AI trading agent on smartphone dashboard"
+        imageSrc="/images/diagram-research-flow.png"
+        imageAlt="AI agent research flow diagram"
+        imageClassName="object-contain p-4"
       />
 
       <AgentsTeamSection />

--- a/components/landing/feature-story-section.tsx
+++ b/components/landing/feature-story-section.tsx
@@ -11,8 +11,7 @@ interface FeatureStorySectionProps {
   ctaHref: string
   imageSrc: string
   imageAlt: string
-  /** Renders on a fixed dark "ink" band instead of the theme background */
-  ink?: boolean
+  imageClassName?: string
   /** Puts the image on the right on desktop */
   reverse?: boolean
 }
@@ -26,49 +25,37 @@ export function FeatureStorySection({
   ctaHref,
   imageSrc,
   imageAlt,
-  ink = false,
+  imageClassName = "object-cover",
   reverse = false,
 }: FeatureStorySectionProps) {
   return (
-    <section id={id} className={cn(ink ? "bg-ink text-cream" : "bg-background text-foreground")}>
+    <section id={id} className="bg-background text-foreground">
       <div
         className={cn(
           "mx-auto grid max-w-[1400px] items-center gap-12 px-6 py-20 md:grid-cols-2 md:py-28",
           reverse && "md:[&>*:first-child]:order-2",
         )}
       >
-        <div className="relative aspect-[4/3] overflow-hidden rounded-3xl">
+        <div className="relative aspect-[4/3] overflow-hidden rounded-3xl border border-border bg-card/60">
           <Image
             src={imageSrc}
             alt={imageAlt}
             fill
             sizes="(min-width: 768px) 50vw, 100vw"
-            className="object-cover"
+            className={imageClassName}
           />
         </div>
         <div className="max-w-xl">
-          <div
-            className={cn(
-              "text-xs uppercase tracking-[0.2em]",
-              ink ? "text-emerald-400" : "text-bronze",
-            )}
-          >
+          <div className="text-xs uppercase tracking-[0.2em] text-bronze">
             {eyebrow}
           </div>
           <h2 className="font-display mt-4 text-[clamp(2.25rem,4.5vw,4rem)] leading-[1.02] tracking-tight">
             {title}
           </h2>
-          <p className={cn("mt-6 text-lg", ink ? "text-cream/70" : "text-muted-foreground")}>
-            {description}
-          </p>
+          <p className="mt-6 text-lg text-muted-foreground">{description}</p>
           <Link
             href={ctaHref}
-            className={cn(
-              "mt-8 inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-medium transition",
-              ink
-                ? "bg-emerald-400 text-ink hover:brightness-95"
-                : "border border-foreground text-foreground hover:bg-foreground hover:text-background",
-            )}
+            className="mt-8 inline-flex items-center gap-2 rounded-full border border-foreground px-6 py-3 text-sm font-medium text-foreground transition hover:bg-foreground hover:text-background"
           >
             {ctaLabel} →
           </Link>

--- a/components/landing/final-cta-section.tsx
+++ b/components/landing/final-cta-section.tsx
@@ -4,30 +4,33 @@ export function FinalCtaSection() {
   return (
     <section className="relative py-24 lg:py-32">
       <div className="mx-auto max-w-7xl px-5 lg:px-8">
-        <div className="relative overflow-hidden rounded-[2rem] bg-ink p-10 text-cream lg:p-16">
+        <div className="relative overflow-hidden rounded-[2rem] border border-border bg-card p-10 text-card-foreground lg:p-16">
           <div className="pointer-events-none absolute -right-20 -top-20 h-72 w-72 rounded-full bg-emerald-500/30 blur-3xl" />
           <div className="pointer-events-none absolute -bottom-32 -left-10 h-72 w-72 rounded-full bg-violet-500/20 blur-3xl" />
           <div className="relative max-w-2xl">
-            <div className="text-xs uppercase tracking-[0.2em] text-emerald-400">Get started</div>
+            <div className="text-xs uppercase tracking-[0.2em] text-emerald-400">
+              Get started
+            </div>
             <h2 className="font-display mt-4 text-5xl leading-[1.02] tracking-tight lg:text-7xl">
               Your first
-              <br /> <em className="not-italic text-emerald-400">AI portfolio</em>
+              <br />{" "}
+              <em className="not-italic text-emerald-400">AI portfolio</em>
               <br /> in 90 seconds.
             </h2>
-            <p className="mt-6 max-w-lg text-lg text-cream/70">
-              Connect a broker, pick a risk profile, and let the team of agents get to work. Cancel
-              anytime. Your keys, your account.
+            <p className="mt-6 max-w-lg text-lg text-muted-foreground">
+              Connect a broker, pick a risk profile, and let the team of agents
+              get to work. Cancel anytime. Your keys, your account.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
               <Link
                 href="/login"
-                className="rounded-full bg-emerald-400 px-7 py-3.5 text-sm font-semibold text-ink transition hover:brightness-95"
+                className="rounded-full bg-primary px-7 py-3.5 text-sm font-semibold text-primary-foreground transition hover:brightness-95"
               >
                 Create free account
               </Link>
               <Link
                 href="/docs"
-                className="rounded-full border border-cream/25 px-7 py-3.5 text-sm text-cream transition hover:bg-cream/10"
+                className="rounded-full border border-border px-7 py-3.5 text-sm text-foreground transition hover:bg-accent hover:text-accent-foreground"
               >
                 Read the docs
               </Link>

--- a/components/landing/footer.tsx
+++ b/components/landing/footer.tsx
@@ -36,14 +36,17 @@ const columns = [
     links: [
       { label: "Terms & Privacy", href: "/legal/privacy" },
       { label: "Contact", href: "mailto:contact@autoinvestment.broker" },
-      { label: "Google Play", href: "https://play.google.com/store/apps/details?id=com.autoinvestment.broker.app" },
+      {
+        label: "Google Play",
+        href: "https://play.google.com/store/apps/details?id=com.autoinvestment.broker.app",
+      },
     ],
   },
 ]
 
 export function Footer() {
   return (
-    <footer className="bg-ink text-cream">
+    <footer className="border-t border-border bg-background text-foreground">
       <div className="mx-auto max-w-[1400px] px-6 py-16">
         <div className="grid gap-12 md:grid-cols-[1.5fr_repeat(4,1fr)]">
           <div>
@@ -59,14 +62,15 @@ export function Footer() {
               </div>
               <span className="font-display text-2xl">{APP_NAME}</span>
             </div>
-            <p className="mt-4 max-w-xs text-sm text-cream/60">
-              Auto-invest like a hedge fund. AI agents that research, debate, and trade — for you.
+            <p className="mt-4 max-w-xs text-sm text-muted-foreground">
+              Auto-invest like a hedge fund. AI agents that research, debate,
+              and trade — for you.
             </p>
           </div>
 
           {columns.map((column) => (
             <div key={column.heading}>
-              <div className="text-xs uppercase tracking-[0.2em] text-cream/50">
+              <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">
                 {column.heading}
               </div>
               <ul className="mt-4 space-y-2 text-sm">
@@ -74,7 +78,7 @@ export function Footer() {
                   <li key={link.label}>
                     <Link
                       href={link.href}
-                      className="text-cream/80 transition-colors hover:text-emerald-400"
+                      className="text-muted-foreground transition-colors hover:text-primary"
                     >
                       {link.label}
                     </Link>
@@ -85,9 +89,10 @@ export function Footer() {
           ))}
         </div>
 
-        <div className="mt-16 flex flex-col justify-between gap-4 border-t border-cream/10 pt-8 text-xs text-cream/50 sm:flex-row">
+        <div className="mt-16 flex flex-col justify-between gap-4 border-t border-border pt-8 text-xs text-muted-foreground sm:flex-row">
           <div>
-            © {new Date().getFullYear()} {APP_NAME}. San Francisco, CA. All rights reserved.
+            © {new Date().getFullYear()} {APP_NAME}. San Francisco, CA. All
+            rights reserved.
           </div>
           <div>Investing involves risk of loss. Not investment advice.</div>
         </div>

--- a/components/landing/prediction-markets-preview.tsx
+++ b/components/landing/prediction-markets-preview.tsx
@@ -2,14 +2,21 @@ import Link from "next/link"
 
 const markets = [
   { question: "Will the Fed cut rates in Q1 2026?", volume: "$4.2M", yes: 68 },
-  { question: "Will NVDA close above $150 by end of quarter?", volume: "$2.8M", yes: 54 },
+  {
+    question: "Will NVDA close above $150 by end of quarter?",
+    volume: "$2.8M",
+    yes: 54,
+  },
   { question: "Will OpenAI ship GPT-6 in 2026?", volume: "$6.1M", yes: 41 },
   { question: "Will BTC hit $150K this year?", volume: "$12.4M", yes: 37 },
 ]
 
 export function PredictionMarketsPreview() {
   return (
-    <section id="prediction-markets" className="relative bg-ink py-24 text-cream lg:py-32">
+    <section
+      id="prediction-markets"
+      className="relative bg-background py-24 text-foreground lg:py-32"
+    >
       <div className="pointer-events-none absolute -right-24 -top-24 h-96 w-96 rounded-full bg-emerald-500/15 blur-3xl" />
       <div className="mx-auto max-w-7xl px-5 lg:px-8">
         <div className="grid gap-12 lg:grid-cols-[1fr_1.2fr] lg:items-center">
@@ -18,29 +25,45 @@ export function PredictionMarketsPreview() {
               Prediction Markets
             </div>
             <h2 className="font-display mt-3 text-4xl tracking-tight lg:text-6xl">
-              Bet on <em className="not-italic text-emerald-400">what happens next.</em>
+              Bet on{" "}
+              <em className="not-italic text-emerald-400">
+                what happens next.
+              </em>
             </h2>
-            <p className="mt-6 max-w-md text-cream/70">
-              Our LLM outcome engine reads every relevant filing, tweet, and headline, then routes
-              your capital to the sharpest edge on Polymarket and Kalshi — automatically.
+            <p className="mt-6 max-w-md text-muted-foreground">
+              Our LLM outcome engine reads every relevant filing, tweet, and
+              headline, then routes your capital to the sharpest edge on
+              Polymarket and Kalshi — automatically.
             </p>
             <div className="mt-8 flex flex-wrap gap-6 text-sm">
               <div>
-                <div className="text-2xl font-semibold tracking-tight">12,400+</div>
-                <div className="text-xs uppercase tracking-wider text-cream/50">Markets tracked</div>
+                <div className="text-2xl font-semibold tracking-tight">
+                  12,400+
+                </div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Markets tracked
+                </div>
               </div>
               <div>
-                <div className="text-2xl font-semibold tracking-tight">+11.8%</div>
-                <div className="text-xs uppercase tracking-wider text-cream/50">Avg agent edge</div>
+                <div className="text-2xl font-semibold tracking-tight">
+                  +11.8%
+                </div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Avg agent edge
+                </div>
               </div>
               <div>
-                <div className="text-2xl font-semibold tracking-tight">Enabled</div>
-                <div className="text-xs uppercase tracking-wider text-cream/50">Auto-hedge</div>
+                <div className="text-2xl font-semibold tracking-tight">
+                  Enabled
+                </div>
+                <div className="text-xs uppercase tracking-wider text-muted-foreground">
+                  Auto-hedge
+                </div>
               </div>
             </div>
             <Link
               href="/predict"
-              className="mt-8 inline-flex items-center gap-2 rounded-full bg-emerald-400 px-6 py-3 text-sm font-medium text-ink transition hover:brightness-95"
+              className="mt-8 inline-flex items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-medium text-primary-foreground transition hover:brightness-95"
             >
               See live markets →
             </Link>
@@ -50,11 +73,11 @@ export function PredictionMarketsPreview() {
             {markets.map((market) => (
               <div
                 key={market.question}
-                className="rounded-2xl border border-white/10 bg-white/5 p-5 backdrop-blur transition-colors hover:border-emerald-400/40"
+                className="rounded-2xl border border-border bg-card/60 p-5 backdrop-blur transition-colors hover:border-emerald-400/40"
               >
                 <div className="flex items-start justify-between gap-4">
                   <p className="font-medium">{market.question}</p>
-                  <span className="shrink-0 font-mono text-xs text-cream/50">
+                  <span className="shrink-0 font-mono text-xs text-muted-foreground">
                     Vol {market.volume}
                   </span>
                 </div>
@@ -62,11 +85,11 @@ export function PredictionMarketsPreview() {
                   <div className="flex-1 rounded-lg border border-emerald-400/40 bg-emerald-400/10 py-2.5 text-center text-sm font-semibold text-emerald-400">
                     Yes · {market.yes}¢
                   </div>
-                  <div className="flex-1 rounded-lg border border-white/10 bg-white/5 py-2.5 text-center text-sm font-semibold">
+                  <div className="flex-1 rounded-lg border border-border bg-card/60 py-2.5 text-center text-sm font-semibold">
                     No · {100 - market.yes}¢
                   </div>
                 </div>
-                <div className="mt-3 h-1 overflow-hidden rounded-full bg-white/10">
+                <div className="mt-3 h-1 overflow-hidden rounded-full bg-muted">
                   <div
                     style={{ width: `${market.yes}%` }}
                     className="h-full rounded-full bg-emerald-400"

--- a/components/landing/ticker-tape.tsx
+++ b/components/landing/ticker-tape.tsx
@@ -18,13 +18,23 @@ const tickers = [
 
 export function TickerTape() {
   return (
-    <div className="border-y border-white/10 bg-ink py-1 text-cream">
+    <div className="border-y border-border bg-background py-1 text-foreground">
       <Marquee className="[--duration:50s] [--gap:2.5rem] p-2">
         {tickers.map((t) => (
-          <span key={t.symbol} className="flex items-center gap-3 text-sm whitespace-nowrap">
-            <span className="font-mono font-semibold tracking-tight">{t.symbol}</span>
-            <span className="font-mono text-cream/50">{t.price}</span>
-            <span className={cn("font-mono", t.up ? "text-emerald-400" : "text-red-400")}>
+          <span
+            key={t.symbol}
+            className="flex items-center gap-3 text-sm whitespace-nowrap"
+          >
+            <span className="font-mono font-semibold tracking-tight">
+              {t.symbol}
+            </span>
+            <span className="font-mono text-muted-foreground">{t.price}</span>
+            <span
+              className={cn(
+                "font-mono",
+                t.up ? "text-emerald-400" : "text-red-400",
+              )}
+            >
               {t.change}
             </span>
           </span>


### PR DESCRIPTION
### Motivation
- Restore the research flow diagram on the homepage so the diagram PNG displays correctly in the Agentic Trading feature. 
- Remove fixed dark-only landing styles so homepage subcomponents use the light/dark theme tokens and can adapt to theme mode.

### Description
- Replaced the Agentic Trading photo with `/images/diagram-research-flow.png` and added an `imageClassName` override so diagrams can render with `object-contain` while photos keep `object-cover` (`app/page.tsx`, `components/landing/feature-story-section.tsx`).
- Simplified `FeatureStorySection` by removing the fixed `ink` path, adding `imageClassName?: string`, and switching the wrapper to theme-aware tokens with a card border and contained image area (`components/landing/feature-story-section.tsx`).
- Replaced fixed dark/background classes (`bg-ink`, `text-cream`, `bg-white/5`, `border-white/10`, etc.) with theme tokens (`bg-background`, `bg-card/60`, `border-border`, `text-foreground`, `text-muted-foreground`, `bg-primary`, etc.) across homepage subcomponents: prediction markets preview, final CTA, footer, and ticker tape (`components/landing/prediction-markets-preview.tsx`, `components/landing/final-cta-section.tsx`, `components/landing/footer.tsx`, `components/landing/ticker-tape.tsx`).
- Ran code formatting (Prettier) across the edited files and applied stylistic cleanups for consistent imports/formatting.

### Testing
- Ran `prettier --write` / `prettier --check` against the modified files and the check passed. 
- Verified visual class replacements by inspecting the modified component markup and ensuring image is rendered with the provided `imageClassName` on the homepage. 
- Ran `npx tsc --noEmit`, which surfaced existing unresolved project dependency/type issues in the environment (missing `next/server`, `drizzle-orm`, Node type globals, and unrelated type errors), so a full type build could not be validated in this workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4747ab714c8320902a1010912a329e)