### PR TITLE
Add zoomable research diagram lightbox

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,11 +22,12 @@ export default function LandingPage() {
         eyebrow="Agentic Trading"
         title="Send your agent to the market"
         description="Give your AI agent a dedicated brokerage account. It researches, debates competing theses, then places trades — you monitor performance in one calm dashboard."
-        ctaLabel="Meet the agents"
-        ctaHref="/debate"
         imageSrc="/images/diagram-research-flow.png"
         imageAlt="AI agent research flow diagram"
-        imageClassName="object-contain p-4"
+        imageClassName="object-contain p-1"
+        imagePriority
+        imageWide
+        imageZoomable
       />
 
       <AgentsTeamSection />

--- a/components/landing/feature-story-section.tsx
+++ b/components/landing/feature-story-section.tsx
@@ -1,17 +1,29 @@
+"use client"
+
 import Image from "next/image"
 import Link from "next/link"
 import { cn } from "@/lib/utils"
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
 
 interface FeatureStorySectionProps {
   id?: string
   eyebrow: string
   title: React.ReactNode
   description: string
-  ctaLabel: string
-  ctaHref: string
+  ctaLabel?: string
+  ctaHref?: string
   imageSrc: string
   imageAlt: string
   imageClassName?: string
+  imageContainerClassName?: string
+  imagePriority?: boolean
+  imageZoomable?: boolean
+  imageWide?: boolean
   /** Puts the image on the right on desktop */
   reverse?: boolean
 }
@@ -26,25 +38,80 @@ export function FeatureStorySection({
   imageSrc,
   imageAlt,
   imageClassName = "object-cover",
+  imageContainerClassName,
+  imagePriority = false,
+  imageZoomable = false,
+  imageWide = false,
   reverse = false,
 }: FeatureStorySectionProps) {
+  const imageCard = (
+    <div
+      className={cn(
+        "relative aspect-[4/3] overflow-hidden rounded-3xl border border-border bg-card/60",
+        imageZoomable &&
+          "cursor-zoom-in transition duration-300 hover:border-bronze/70 hover:shadow-2xl hover:shadow-bronze/10",
+        imageContainerClassName,
+      )}
+    >
+      <Image
+        src={imageSrc}
+        alt={imageAlt}
+        fill
+        sizes={
+          imageWide
+            ? "(min-width: 768px) 62vw, 100vw"
+            : "(min-width: 768px) 50vw, 100vw"
+        }
+        priority={imagePriority}
+        className={imageClassName}
+      />
+      {imageZoomable && (
+        <span className="absolute bottom-4 right-4 rounded-full bg-background/85 px-3 py-1 text-xs font-medium text-foreground shadow-sm backdrop-blur">
+          Click to zoom
+        </span>
+      )}
+    </div>
+  )
+
   return (
     <section id={id} className="bg-background text-foreground">
       <div
         className={cn(
           "mx-auto grid max-w-[1400px] items-center gap-12 px-6 py-20 md:grid-cols-2 md:py-28",
+          imageWide && "max-w-[1600px] md:grid-cols-[1.25fr_0.75fr]",
           reverse && "md:[&>*:first-child]:order-2",
         )}
       >
-        <div className="relative aspect-[4/3] overflow-hidden rounded-3xl border border-border bg-card/60">
-          <Image
-            src={imageSrc}
-            alt={imageAlt}
-            fill
-            sizes="(min-width: 768px) 50vw, 100vw"
-            className={imageClassName}
-          />
-        </div>
+        {imageZoomable ? (
+          <Dialog>
+            <DialogTrigger asChild>
+              <button
+                type="button"
+                className="group block text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-bronze focus-visible:ring-offset-4 focus-visible:ring-offset-background"
+                aria-label={`Open larger view of ${imageAlt}`}
+              >
+                {imageCard}
+              </button>
+            </DialogTrigger>
+            <DialogContent
+              className="max-h-[92vh] max-w-[min(96vw,1400px)] overflow-hidden border-border bg-background/95 p-3"
+              showCloseButton
+            >
+              <DialogTitle className="sr-only">{imageAlt}</DialogTitle>
+              <div className="relative h-[82vh] w-full">
+                <Image
+                  src={imageSrc}
+                  alt={imageAlt}
+                  fill
+                  sizes="96vw"
+                  className="object-contain"
+                />
+              </div>
+            </DialogContent>
+          </Dialog>
+        ) : (
+          imageCard
+        )}
         <div className="max-w-xl">
           <div className="text-xs uppercase tracking-[0.2em] text-bronze">
             {eyebrow}
@@ -53,12 +120,14 @@ export function FeatureStorySection({
             {title}
           </h2>
           <p className="mt-6 text-lg text-muted-foreground">{description}</p>
-          <Link
-            href={ctaHref}
-            className="mt-8 inline-flex items-center gap-2 rounded-full border border-foreground px-6 py-3 text-sm font-medium text-foreground transition hover:bg-foreground hover:text-background"
-          >
-            {ctaLabel} →
-          </Link>
+          {ctaLabel && ctaHref && (
+            <Link
+              href={ctaHref}
+              className="mt-8 inline-flex items-center gap-2 rounded-full border border-foreground px-6 py-3 text-sm font-medium text-foreground transition hover:bg-foreground hover:text-background"
+            >
+              {ctaLabel} →
+            </Link>
+          )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
### Motivation
- Improve the landing presentation of the agentic trading research flow so the diagram is larger and can be inspected in detail.  
- Remove the CTA from that feature block when the section should not link elsewhere.  
- Provide a reusable, accessible lightbox pattern for feature images so other sections can optionally enable zoom.

### Description
- Convert `FeatureStorySection` to a client component and add optional props: `imagePriority`, `imageZoomable`, `imageWide`, and `imageContainerClassName` to control sizing and behavior.  
- Implement an image card and conditional Radix dialog lightbox using `Dialog`, `DialogTrigger`, `DialogContent`, and `DialogTitle` to show an enlarged view with an accessible `aria-label` and visually hidden title.  
- Make CTA rendering optional by making `ctaLabel`/`ctaHref` optional and only rendering the link when both are provided.  
- Update the landing page to remove the "Meet the agents" CTA for the Agentic Trading block and enable `imagePriority`, `imageWide`, and `imageZoomable` with reduced padding for the research-flow diagram.

### Testing
- Ran `npm run build` to validate the app build, but it failed because project dependencies are not installed in the environment (`next: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47520b36c8832081d992d3aad1b905)