### PR TITLE
Wire up teams and invitations to Cloudflare D1 + Email Workers

### DIFF
--- a/apps/ai-broker-web/app/api/invitations/route.ts
+++ b/apps/ai-broker-web/app/api/invitations/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth"
 import { db } from "@/lib/db"
 import { userInvitations, users, notifications } from "@/lib/db/schema"
 import { eq, and } from "drizzle-orm"
+import { sendEmail, renderEmailLayout, renderEmailButton } from "@/lib/email/send-email"
 
 // GET - Get user's sent and received invitations
 export async function GET(request: NextRequest) {
@@ -106,8 +107,16 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // TODO: Send email invitation
-    // You can integrate with a service like Resend, SendGrid, or Nodemailer here
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://autoinvestment.broker"
+    const acceptUrl = `${appUrl}/sign-up?invite=${invitation.id}`
+    await sendEmail({
+      to: email,
+      subject: `${session.user.name} invited you`,
+      html: renderEmailLayout(
+        "You've been invited",
+        `<p>${session.user.name} invited you to join${organizationId ? " their organization" : ""}.</p>${renderEmailButton("Accept Invitation", acceptUrl)}<p style="color:#888;font-size:12px;">This invitation expires in 7 days.</p>`
+      ),
+    })
 
     return NextResponse.json({
       success: true,

--- a/apps/ai-broker-web/app/api/share/route.ts
+++ b/apps/ai-broker-web/app/api/share/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth"
 import { db } from "@/lib/db"
 import { sharedItems, notifications, users } from "@/lib/db/schema"
 import { eq } from "drizzle-orm"
+import { sendEmail, renderEmailLayout, renderEmailButton } from "@/lib/email/send-email"
 
 // GET - Get items shared with user
 export async function GET(request: NextRequest) {
@@ -118,8 +119,19 @@ export async function POST(request: NextRequest) {
       })
     }
 
-    // TODO: Send email to recipient
-    // Integrate with email service (Resend, SendGrid, etc.)
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://autoinvestment.broker"
+    const itemLabel = itemType.replace("_", " ")
+    const viewUrl = recipient.length > 0
+      ? `${appUrl}/shared/${sharedItem.id}`
+      : `${appUrl}/sign-up?redirect=/shared/${sharedItem.id}`
+    await sendEmail({
+      to: email,
+      subject: `${session.user.name} shared ${symbol ? symbol + " " : ""}${itemLabel} with you`,
+      html: renderEmailLayout(
+        "Shared with you",
+        `<p>${session.user.name} shared a ${itemLabel}${symbol ? ` for <strong>${symbol}</strong>` : ""} with you${title ? `: <strong>${title}</strong>` : ""}.</p>${message ? `<p style="font-style:italic;">"${message}"</p>` : ""}${renderEmailButton("View", viewUrl)}`
+      ),
+    })
 
     return NextResponse.json({
       success: true,

--- a/apps/ai-broker-web/app/api/teams/[id]/invite/route.ts
+++ b/apps/ai-broker-web/app/api/teams/[id]/invite/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { db } from "@/lib/db"
+import {
+  teams,
+  teamMembers,
+  organizations,
+  organizationMembers,
+  users,
+  userInvitations,
+  notifications,
+} from "@/lib/db/schema"
+import { eq, and } from "drizzle-orm"
+import { sendEmail, renderEmailLayout, renderEmailButton } from "@/lib/email/send-email"
+
+// POST - Invite a user (by email) to a team. Adds existing users directly;
+// emails a signup invitation (via Cloudflare Email Workers) to everyone else.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    })
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const teamId = params.id
+    const body = await request.json()
+    const { email } = body
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "Email is required" }, { status: 400 })
+    }
+
+    const team = await db.select().from(teams).where(eq(teams.id, teamId)).limit(1)
+    if (team.length === 0) {
+      return NextResponse.json({ error: "Team not found" }, { status: 404 })
+    }
+
+    const orgMembership = await db
+      .select()
+      .from(organizationMembers)
+      .where(
+        and(
+          eq(organizationMembers.organizationId, team[0].organizationId),
+          eq(organizationMembers.userId, session.user.id)
+        )
+      )
+      .limit(1)
+
+    const teamMembership = await db
+      .select()
+      .from(teamMembers)
+      .where(
+        and(
+          eq(teamMembers.teamId, teamId),
+          eq(teamMembers.userId, session.user.id)
+        )
+      )
+      .limit(1)
+
+    const isOrgAdmin = orgMembership.length > 0 && ["owner", "admin"].includes(orgMembership[0].role)
+    const isTeamLead = teamMembership.length > 0 && teamMembership[0].role === "lead"
+
+    if (!isOrgAdmin && !isTeamLead) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    }
+
+    const org = await db
+      .select()
+      .from(organizations)
+      .where(eq(organizations.id, team[0].organizationId))
+      .limit(1)
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL || "https://autoinvestment.broker"
+    const existingUser = await db.select().from(users).where(eq(users.email, email)).limit(1)
+
+    if (existingUser.length > 0) {
+      const userId = existingUser[0].id
+
+      if (userId === session.user.id) {
+        return NextResponse.json({ error: "Cannot invite yourself" }, { status: 400 })
+      }
+
+      const alreadyInTeam = await db
+        .select()
+        .from(teamMembers)
+        .where(and(eq(teamMembers.teamId, teamId), eq(teamMembers.userId, userId)))
+        .limit(1)
+
+      if (alreadyInTeam.length > 0) {
+        return NextResponse.json({ error: "User is already a team member" }, { status: 400 })
+      }
+
+      const alreadyInOrg = await db
+        .select()
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.organizationId, team[0].organizationId),
+            eq(organizationMembers.userId, userId)
+          )
+        )
+        .limit(1)
+
+      if (alreadyInOrg.length === 0) {
+        await db.insert(organizationMembers).values({
+          id: crypto.randomUUID(),
+          organizationId: team[0].organizationId,
+          userId,
+          role: "member",
+          joinedAt: new Date(),
+        })
+      }
+
+      await db.insert(teamMembers).values({
+        id: crypto.randomUUID(),
+        teamId,
+        userId,
+        role: "member",
+        joinedAt: new Date(),
+      })
+
+      await db.insert(notifications).values({
+        id: crypto.randomUUID(),
+        userId,
+        type: "invite",
+        title: "Added to a team",
+        message: `${session.user.name} added you to ${team[0].name}`,
+        fromUserId: session.user.id,
+        relatedItemType: "team",
+        relatedItemId: teamId,
+        read: false,
+        createdAt: new Date(),
+      })
+
+      await sendEmail({
+        to: email,
+        subject: `You've been added to ${team[0].name}`,
+        html: renderEmailLayout(
+          "You're on the team!",
+          `<p>${session.user.name} added you to the <strong>${team[0].name}</strong> team${org.length ? ` in ${org[0].name}` : ""}.</p>${renderEmailButton("Go to Dashboard", `${appUrl}/dashboard`)}`
+        ),
+      })
+
+      return NextResponse.json({ success: true, invited: false, message: "Member added" })
+    }
+
+    // No account with this email yet -- create a pending invitation and email it.
+    const now = new Date()
+    const expiresAt = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
+    const invitationId = crypto.randomUUID()
+
+    await db.insert(userInvitations).values({
+      id: invitationId,
+      inviterId: session.user.id,
+      email,
+      status: "pending",
+      organizationId: team[0].organizationId,
+      teamId,
+      expiresAt,
+      createdAt: now,
+    })
+
+    const acceptUrl = `${appUrl}/sign-up?invite=${invitationId}`
+    await sendEmail({
+      to: email,
+      subject: `${session.user.name} invited you to join ${team[0].name}`,
+      html: renderEmailLayout(
+        "You've been invited",
+        `<p>${session.user.name} invited you to join the <strong>${team[0].name}</strong> team.</p>${renderEmailButton("Accept Invitation", acceptUrl)}<p style="color:#888;font-size:12px;">This invitation expires in 7 days.</p>`
+      ),
+    })
+
+    return NextResponse.json({ success: true, invited: true, message: "Invitation email sent" })
+  } catch (error: any) {
+    console.error("Error inviting team member:", error)
+    return NextResponse.json(
+      { error: error.message || "Failed to invite member" },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/ai-broker-web/app/api/teams/[id]/route.ts
+++ b/apps/ai-broker-web/app/api/teams/[id]/route.ts
@@ -127,15 +127,16 @@ export async function PATCH(
     }
 
     const body = await request.json()
-    const { name, description } = body
+    const { name, description, upgradeMembers } = body
+
+    const updates: Record<string, unknown> = { updatedAt: new Date() }
+    if (name !== undefined) updates.name = name
+    if (description !== undefined) updates.description = description
+    if (upgradeMembers !== undefined) updates.upgradeMembers = !!upgradeMembers
 
     await db
       .update(teams)
-      .set({
-        name,
-        description,
-        updatedAt: new Date(),
-      })
+      .set(updates)
       .where(eq(teams.id, teamId))
 
     return NextResponse.json({

--- a/apps/ai-broker-web/app/api/teams/route.ts
+++ b/apps/ai-broker-web/app/api/teams/route.ts
@@ -1,10 +1,60 @@
 import { NextRequest, NextResponse } from "next/server"
 import { auth } from "@/lib/auth"
 import { db } from "@/lib/db"
-import { teams, teamMembers, organizationMembers } from "@/lib/db/schema"
-import { eq, and } from "drizzle-orm"
+import { teams, teamMembers, organizations, organizationMembers } from "@/lib/db/schema"
+import { eq, and, inArray } from "drizzle-orm"
 
-// POST - Create new team
+// GET - List teams the current user belongs to (via organization membership),
+// with nested members and their user info.
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    })
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const memberships = await db
+      .select({ organizationId: organizationMembers.organizationId })
+      .from(organizationMembers)
+      .where(eq(organizationMembers.userId, session.user.id))
+
+    if (memberships.length === 0) {
+      return NextResponse.json({ success: true, data: [] })
+    }
+
+    const orgIds = memberships.map((m) => m.organizationId)
+
+    const userTeams = await db.query.teams.findMany({
+      where: inArray(teams.organizationId, orgIds),
+      with: {
+        members: {
+          with: {
+            user: {
+              columns: { id: true, name: true, email: true, image: true },
+            },
+          },
+        },
+      },
+    })
+
+    return NextResponse.json({
+      success: true,
+      data: userTeams,
+    })
+  } catch (error: any) {
+    console.error("Error fetching teams:", error)
+    return NextResponse.json(
+      { error: error.message || "Failed to fetch teams" },
+      { status: 500 }
+    )
+  }
+}
+
+// POST - Create new team. If organizationId is omitted, the caller's personal
+// organization is used (created on first use).
 export async function POST(request: NextRequest) {
   try {
     const session = await auth.api.getSession({
@@ -16,13 +66,44 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { organizationId, name, description } = body
+    let { organizationId, name, description, upgradeMembers } = body
 
-    if (!organizationId || !name) {
-      return NextResponse.json(
-        { error: "Organization ID and name are required" },
-        { status: 400 }
-      )
+    if (!name) {
+      return NextResponse.json({ error: "Name is required" }, { status: 400 })
+    }
+
+    if (!organizationId) {
+      const ownedOrg = await db
+        .select()
+        .from(organizationMembers)
+        .where(
+          and(
+            eq(organizationMembers.userId, session.user.id),
+            eq(organizationMembers.role, "owner")
+          )
+        )
+        .limit(1)
+
+      if (ownedOrg.length > 0) {
+        organizationId = ownedOrg[0].organizationId
+      } else {
+        const now = new Date()
+        organizationId = crypto.randomUUID()
+        await db.insert(organizations).values({
+          id: organizationId,
+          name: session.user.name ? `${session.user.name}'s Organization` : "My Organization",
+          ownerId: session.user.id,
+          createdAt: now,
+          updatedAt: now,
+        })
+        await db.insert(organizationMembers).values({
+          id: crypto.randomUUID(),
+          organizationId,
+          userId: session.user.id,
+          role: "owner",
+          joinedAt: now,
+        })
+      }
     }
 
     // Check if user is a member of the organization
@@ -49,6 +130,7 @@ export async function POST(request: NextRequest) {
       organizationId,
       name,
       description: description || null,
+      upgradeMembers: !!upgradeMembers,
       createdAt: now,
       updatedAt: now,
     }

--- a/apps/ai-broker-web/app/api/users/search/route.ts
+++ b/apps/ai-broker-web/app/api/users/search/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server"
+import { auth } from "@/lib/auth"
+import { db } from "@/lib/db"
+import { users } from "@/lib/db/schema"
+import { and, like, ne, or } from "drizzle-orm"
+
+// GET - Search users by name or email (for team invite autocomplete)
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth.api.getSession({
+      headers: request.headers,
+    })
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const query = (searchParams.get("q") || "").trim()
+
+    if (query.length < 2) {
+      return NextResponse.json({ success: true, data: [] })
+    }
+
+    const pattern = `%${query}%`
+    const results = await db
+      .select({
+        id: users.id,
+        name: users.name,
+        email: users.email,
+        image: users.image,
+      })
+      .from(users)
+      .where(
+        and(
+          ne(users.id, session.user.id),
+          or(like(users.name, pattern), like(users.email, pattern))
+        )
+      )
+      .limit(10)
+
+    return NextResponse.json({ success: true, data: results })
+  } catch (error: any) {
+    console.error("Error searching users:", error)
+    return NextResponse.json(
+      { error: error.message || "Failed to search users" },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/ai-broker-web/lib/actions/teams.ts
+++ b/apps/ai-broker-web/lib/actions/teams.ts
@@ -1,34 +1,89 @@
-// Team management actions
-// TODO: Implement team CRUD operations
+// Client-side helpers for team management, backed by the /api/teams,
+// /api/teams/[id]/invite, and /api/users/search routes.
 
-export async function getTeams() {
-  return []
+export interface TeamMemberUser {
+  id: string
+  name: string
+  email: string
+  image?: string | null
 }
 
-export async function getUserTeams() {
-  return []
+export interface TeamMember {
+  id: string
+  role: string
+  user: TeamMemberUser
 }
 
-export async function createTeam(data: any) {
-  throw new Error('Not implemented')
+export interface Team {
+  id: string
+  organizationId: string
+  name: string
+  description: string | null
+  upgradeMembers: boolean
+  members: TeamMember[]
 }
 
-export async function updateTeam(id: string, data: any) {
-  throw new Error('Not implemented')
+async function parseJson(res: Response) {
+  const data = await res.json().catch(() => ({}))
+  return { ok: res.ok, data }
+}
+
+export async function getTeams(): Promise<Team[]> {
+  return getUserTeams()
+}
+
+export async function getUserTeams(): Promise<Team[]> {
+  const res = await fetch("/api/teams")
+  const { ok, data } = await parseJson(res)
+  return ok && data.success ? data.data : []
+}
+
+export async function createTeam(name: string, description?: string, upgradeMembers?: boolean) {
+  const res = await fetch("/api/teams", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, description, upgradeMembers }),
+  })
+  const { ok, data } = await parseJson(res)
+  return ok ? { success: true, data: data.data } : { success: false, error: data.error }
+}
+
+export async function updateTeam(id: string, name: string, description?: string, upgradeMembers?: boolean) {
+  const res = await fetch(`/api/teams/${id}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name, description, upgradeMembers }),
+  })
+  const { ok, data } = await parseJson(res)
+  return ok ? { success: true } : { success: false, error: data.error }
 }
 
 export async function deleteTeam(id: string) {
-  throw new Error('Not implemented')
+  const res = await fetch(`/api/teams/${id}`, { method: "DELETE" })
+  const { ok, data } = await parseJson(res)
+  return ok ? { success: true } : { success: false, error: data.error }
 }
 
 export async function inviteMemberToTeam(teamId: string, email: string) {
-  throw new Error('Not implemented')
+  const res = await fetch(`/api/teams/${teamId}/invite`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email }),
+  })
+  const { ok, data } = await parseJson(res)
+  return ok ? { success: true, invited: !!data.invited } : { success: false, error: data.error }
 }
 
 export async function removeMemberFromTeam(teamId: string, userId: string) {
-  throw new Error('Not implemented')
+  const res = await fetch(`/api/teams/${teamId}/members?userId=${encodeURIComponent(userId)}`, {
+    method: "DELETE",
+  })
+  const { ok, data } = await parseJson(res)
+  return ok ? { success: true } : { success: false, error: data.error }
 }
 
-export async function searchUsers(query: string) {
-  return []
+export async function searchUsers(query: string): Promise<TeamMemberUser[]> {
+  const res = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`)
+  const { ok, data } = await parseJson(res)
+  return ok && data.success ? data.data : []
 }


### PR DESCRIPTION
## Summary

The Cloudflare Workers migration (vinext, D1, Email Workers) landed in #137–#139. This PR finishes the **teams** feature from the `template-vinext-betterauth-shadcn-themes-teams-stripe` starter, which was left stubbed out after that migration:

- `lib/actions/teams.ts` was a non-functional stub (`throw new Error('Not implemented')` everywhere) whose signatures didn't even match what `TeamsManager` calls. Replaced with real fetch-based client actions against `/api/teams`.
- Added `GET /api/teams` — lists the current user's teams with nested members, using the D1/Drizzle relations that were already defined but unused.
- Added `POST /api/teams/[id]/invite` — adds an existing user to the team directly, or creates a pending `userInvitations` row and emails a signup invite via `lib/email/send-email.ts` (Cloudflare Email Workers, falling back to Resend/console per the existing provider chain).
- Added `GET /api/users/search` for the invite-by-email autocomplete already built into the UI.
- `POST /api/teams` now auto-creates the caller's personal organization when none is supplied (the UI never sends one); create/update now persist the `upgradeMembers` (Pro team) toggle the UI already exposes.
- Replaced the `// TODO: Send email` stubs in `/api/invitations` and `/api/share` with real `sendEmail()` calls through the same CF email module.

## Test plan

- [ ] `bun run type-check` in `apps/ai-broker-web`
- [ ] Create a team, invite an existing user (added directly + notified by email) and a non-existing email (invitation row created + signup email sent) via the Settings → Teams UI
- [ ] Verify emails send through the `SEND_EMAIL` Cloudflare binding in a deployed/preview Worker (falls back to console logging locally without the binding)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AgR3uAnj9BzdbJUjH8TKmK)_