### PR TITLE
Add yahoo-finance2 and node-fetch to Vite external dependencies

### DIFF
--- a/packages/investing/vite.config.ts
+++ b/packages/investing/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         "axios", "csv-parse", "date-fns", "dotenv", "drizzle-orm",
         "ethers", "indicatorts", "langchain", "nanoid",
         "predictos", "sec-edgar-toolkit", "xgboost_node", "zod",
+        "yahoo-finance2", "node-fetch",
       ],
     },
     terserOptions: {


### PR DESCRIPTION
## Summary
Updated the Vite configuration for the investing package to externalize two additional dependencies that should not be bundled.

## Changes
- Added `yahoo-finance2` and `node-fetch` to the list of external dependencies in the Vite config
- These packages are now excluded from the bundle and treated as external modules

## Details
These dependencies are added to the `ssr.noExternal` configuration array in `vite.config.ts`, ensuring they are properly handled during the build process and not included in the final bundle. This is consistent with other external dependencies already configured in the project like `axios`, `ethers`, `langchain`, and others.

https://claude.ai/code/session_0181GeojeGyTtoG7okbB2Apy