### PR TITLE
Clean up unused imports and mark unused parameters with underscore

### DIFF
--- a/packages/fin-data-api/package.json
+++ b/packages/fin-data-api/package.json
@@ -31,8 +31,8 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "helmet": "^7.1.0",
-    "zod": "^3.22.4",
-    "zod-to-json-schema": "^3.22.3"
+    "zod": "3.22.4",
+    "zod-to-json-schema": "3.22.3"
   },
   "devDependencies": {
     "@types/compression": "^1.7.5",

--- a/packages/fin-data-api/src/api/openapi.ts
+++ b/packages/fin-data-api/src/api/openapi.ts
@@ -43,7 +43,7 @@ import { YFinanceQuoteQuerySchema, YFinanceQuoteDataSchema } from '../providers/
 /**
  * Generate OpenAPI 3.0 Specification
  */
-export function generateOpenAPISpec() {
+export function generateOpenAPISpec(): Record<string, unknown> {
   return {
     openapi: '3.0.0',
     info: {

--- a/packages/fin-data-api/src/api/routers/cftcRouter.ts
+++ b/packages/fin-data-api/src/api/routers/cftcRouter.ts
@@ -7,7 +7,7 @@ import { Router, Request, Response } from 'express';
 import { CftcCotFetcher } from '../../providers/cftc/models/cot';
 import { createOBBject, createError } from '../../types/base';
 
-const router = Router();
+const router: Router = Router();
 const fetcher = new CftcCotFetcher();
 
 /**

--- a/packages/fin-data-api/src/api/routers/congressRouter.ts
+++ b/packages/fin-data-api/src/api/routers/congressRouter.ts
@@ -7,7 +7,7 @@ import { Router, Request, Response } from 'express';
 import { CongressBillsFetcher } from '../../providers/congress_gov/models/congressBills';
 import { createOBBject, createError } from '../../types/base';
 
-const router = Router();
+const router: Router = Router();
 const fetcher = new CongressBillsFetcher();
 
 /**

--- a/packages/fin-data-api/src/api/routers/earningsRouter.ts
+++ b/packages/fin-data-api/src/api/routers/earningsRouter.ts
@@ -7,7 +7,7 @@ import { Router, Request, Response } from 'express';
 import { SACalendarEarningsFetcher } from '../../providers/seeking_alpha/models/calendarEarnings';
 import { createOBBject, createError } from '../../types/base';
 
-const router = Router();
+const router: Router = Router();
 const fetcher = new SACalendarEarningsFetcher();
 
 /**

--- a/packages/fin-data-api/src/index.ts
+++ b/packages/fin-data-api/src/index.ts
@@ -40,12 +40,12 @@ app.use((req: Request, res: Response, next: NextFunction) => {
 });
 
 // Health check endpoint
-app.get('/health', (req: Request, res: Response) => {
+app.get('/health', (_req: Request, res: Response) => {
   res.json({ status: 'healthy', timestamp: new Date().toISOString() });
 });
 
 // Root endpoint
-app.get('/', (req: Request, res: Response) => {
+app.get('/', (_req: Request, res: Response) => {
   res.json({
     name: 'Financial Data API',
     version: '1.0.0',
@@ -65,7 +65,7 @@ app.use('/api/earnings', earningsRouter);
 app.use('/api/cftc', cftcRouter);
 
 // OpenAPI JSON endpoint
-app.get('/openapi.json', (req: Request, res: Response) => {
+app.get('/openapi.json', (_req: Request, res: Response) => {
   res.json(generateOpenAPISpec());
 });
 
@@ -95,7 +95,7 @@ app.use((req: Request, res: Response) => {
 });
 
 // Error handler
-app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+app.use((err: Error, _req: Request, res: Response, _next: NextFunction) => {
   console.error('Unhandled error:', err);
   res.status(500).json({
     error: {

--- a/packages/fin-data-api/src/providers/alpha_vantage/models/equityHistorical.ts
+++ b/packages/fin-data-api/src/providers/alpha_vantage/models/equityHistorical.ts
@@ -6,7 +6,7 @@
 import { z } from 'zod';
 import { Fetcher } from '../../../types/base';
 import { makeRequest } from '../../../utils/http';
-import { formatDate, addYears, today } from '../../../utils/dates';
+import { addYears, today } from '../../../utils/dates';
 import { INTERVALS_DICT, getInterval } from '../utils/helpers';
 
 /**

--- a/packages/fin-data-api/src/providers/benzinga/models/worldNews.ts
+++ b/packages/fin-data-api/src/providers/benzinga/models/worldNews.ts
@@ -108,7 +108,7 @@ export class BenzingaWorldNewsFetcher
     return response;
   }
 
-  transformData(query: BenzingaWorldNewsQuery, data: any[]): BenzingaWorldNewsData[] {
+  transformData(_query: BenzingaWorldNewsQuery, data: any[]): BenzingaWorldNewsData[] {
     return data.map((item) => {
       const transformed: any = {
         date: item.created || item.date,

--- a/packages/fin-data-api/src/providers/biztoc/models/news.ts
+++ b/packages/fin-data-api/src/providers/biztoc/models/news.ts
@@ -70,7 +70,7 @@ export class BizTocNewsFetcher implements Fetcher<BizTocNewsQuery, BizTocNewsDat
     return articles.slice(0, query.limit);
   }
 
-  transformData(query: BizTocNewsQuery, data: any[]): BizTocNewsData[] {
+  transformData(_query: BizTocNewsQuery, data: any[]): BizTocNewsData[] {
     return data.map((item) => BizTocNewsDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/bls/models/series.ts
+++ b/packages/fin-data-api/src/providers/bls/models/series.ts
@@ -69,7 +69,7 @@ export class BLSSeriesFetcher implements Fetcher<BLSSeriesQuery, BLSSeriesData> 
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(requestBody),
+      data: requestBody,
     });
 
     if (response.status !== 'REQUEST_SUCCEEDED') {

--- a/packages/fin-data-api/src/providers/cboe/models/index.ts
+++ b/packages/fin-data-api/src/providers/cboe/models/index.ts
@@ -34,7 +34,7 @@ export class CBOEIndexFetcher implements Fetcher<CBOEIndexQuery, CBOEIndexData> 
 
   async extractData(
     query: CBOEIndexQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const symbol = query.symbol.toUpperCase();
     const url = `https://cdn.cboe.com/api/global/delayed_quotes/historical/${symbol}.json`;

--- a/packages/fin-data-api/src/providers/cftc/models/cot.ts
+++ b/packages/fin-data-api/src/providers/cftc/models/cot.ts
@@ -4,7 +4,7 @@
  */
 
 import { z } from 'zod';
-import { Fetcher, QueryParams, Data } from '../../../types/base';
+import { Fetcher } from '../../../types/base';
 import { makeRequest } from '../../../utils/http';
 import { formatDate } from '../../../utils/dates';
 
@@ -170,7 +170,7 @@ export class CftcCotFetcher implements Fetcher<CftcCotQuery, CftcCotData> {
   /**
    * Transform and validate the data
    */
-  transformData(query: CftcCotQuery, data: any[]): CftcCotData[] {
+  transformData(_query: CftcCotQuery, data: any[]): CftcCotData[] {
     const stringCols = [
       'market_and_exchange_names',
       'cftc_contract_market_code',

--- a/packages/fin-data-api/src/providers/congress_gov/models/congressBills.ts
+++ b/packages/fin-data-api/src/providers/congress_gov/models/congressBills.ts
@@ -4,7 +4,7 @@
  */
 
 import { z } from 'zod';
-import { Fetcher, QueryParams, Data } from '../../../types/base';
+import { Fetcher } from '../../../types/base';
 import { BillType, BillTypes, billTypeDocstring } from '../utils/constants';
 import { yearToCongress, getAllBillsByType, getBillsByType } from '../utils/helpers';
 

--- a/packages/fin-data-api/src/providers/deribit/models/options.ts
+++ b/packages/fin-data-api/src/providers/deribit/models/options.ts
@@ -36,7 +36,7 @@ export class DeribitOptionsFetcher implements Fetcher<DeribitOptionsQuery, Derib
 
   async extractData(
     query: DeribitOptionsQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const url =
       `https://www.deribit.com/api/v2/public/get_instruments?` +
@@ -51,7 +51,7 @@ export class DeribitOptionsFetcher implements Fetcher<DeribitOptionsQuery, Derib
     return response.result;
   }
 
-  transformData(query: DeribitOptionsQuery, data: any[]): DeribitOptionsData[] {
+  transformData(_query: DeribitOptionsQuery, data: any[]): DeribitOptionsData[] {
     return data.map((item) =>
       DeribitOptionsDataSchema.parse({
         instrument_name: item.instrument_name,

--- a/packages/fin-data-api/src/providers/ecb/models/exchangeRates.ts
+++ b/packages/fin-data-api/src/providers/ecb/models/exchangeRates.ts
@@ -32,9 +32,8 @@ export class ECBExchangeRatesFetcher
 
   async extractData(
     query: ECBExchangeRatesQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
-    const series = `EXR.D.${query.currency}.EUR.SP00.A`;
     let url = `https://data-api.ecb.europa.eu/service/data/EXR/D.${query.currency}.EUR.SP00.A`;
 
     const params: string[] = [];
@@ -86,7 +85,7 @@ export class ECBExchangeRatesFetcher
     return results;
   }
 
-  transformData(query: ECBExchangeRatesQuery, data: any[]): ECBExchangeRatesData[] {
+  transformData(_query: ECBExchangeRatesQuery, data: any[]): ECBExchangeRatesData[] {
     return data.map((item) => ECBExchangeRatesDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/econdb/models/economicData.ts
+++ b/packages/fin-data-api/src/providers/econdb/models/economicData.ts
@@ -84,7 +84,7 @@ export class EconDBEconomicDataFetcher
     return results;
   }
 
-  transformData(query: EconDBEconomicDataQuery, data: any[]): EconDBEconomicDataData[] {
+  transformData(_query: EconDBEconomicDataQuery, data: any[]): EconDBEconomicDataData[] {
     return data.map((item) => EconDBEconomicDataDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/famafrench/models/factorData.ts
+++ b/packages/fin-data-api/src/providers/famafrench/models/factorData.ts
@@ -5,7 +5,6 @@
 
 import { z } from 'zod';
 import { Fetcher } from '../../../types/base';
-import { makeRequest } from '../../../utils/http';
 
 export const FamaFrenchFactorDataQuerySchema = z.object({
   factor: z
@@ -38,19 +37,9 @@ export class FamaFrenchFactorDataFetcher
   }
 
   async extractData(
-    query: FamaFrenchFactorDataQuery,
-    credentials?: Record<string, string>
+    _query: FamaFrenchFactorDataQuery,
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
-    const baseUrl = 'https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/ftp';
-    const frequencyMap: Record<string, string> = {
-      daily: '_daily',
-      monthly: '',
-      annual: '_annual',
-    };
-
-    const freq = frequencyMap[query.frequency];
-    const url = `${baseUrl}/${query.factor}${freq}_CSV.zip`;
-
     // Note: This requires ZIP file download and CSV parsing
     // Placeholder implementation
     return [

--- a/packages/fin-data-api/src/providers/federal_reserve/models/interestRates.ts
+++ b/packages/fin-data-api/src/providers/federal_reserve/models/interestRates.ts
@@ -5,7 +5,6 @@
 
 import { z } from 'zod';
 import { Fetcher } from '../../../types/base';
-import { makeRequest } from '../../../utils/http';
 
 export const FederalReserveInterestRatesQuerySchema = z.object({
   start_date: z.string().or(z.date()).optional().describe('Start date'),
@@ -41,10 +40,8 @@ export class FederalReserveInterestRatesFetcher
 
   async extractData(
     query: FederalReserveInterestRatesQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
-    const baseUrl = 'https://www.federalreserve.gov/datadownload';
-
     // Note: Federal Reserve data access requires specific parsing
     // Placeholder implementation
     return [
@@ -58,7 +55,7 @@ export class FederalReserveInterestRatesFetcher
   }
 
   transformData(
-    query: FederalReserveInterestRatesQuery,
+    _query: FederalReserveInterestRatesQuery,
     data: any[]
   ): FederalReserveInterestRatesData[] {
     return data.map((item) => FederalReserveInterestRatesDataSchema.parse(item));

--- a/packages/fin-data-api/src/providers/finra/models/shortInterest.ts
+++ b/packages/fin-data-api/src/providers/finra/models/shortInterest.ts
@@ -5,7 +5,6 @@
 
 import { z } from 'zod';
 import { Fetcher } from '../../../types/base';
-import { makeRequest } from '../../../utils/http';
 
 export const FINRAShortInterestQuerySchema = z.object({
   symbol: z.string().describe('Stock symbol'),
@@ -34,7 +33,7 @@ export class FINRAShortInterestFetcher
 
   async extractData(
     query: FINRAShortInterestQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     // FINRA data access requires specific parsing
     // Placeholder implementation
@@ -50,7 +49,7 @@ export class FINRAShortInterestFetcher
     ];
   }
 
-  transformData(query: FINRAShortInterestQuery, data: any[]): FINRAShortInterestData[] {
+  transformData(_query: FINRAShortInterestQuery, data: any[]): FINRAShortInterestData[] {
     return data.map((item) => FINRAShortInterestDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/finviz/models/quote.ts
+++ b/packages/fin-data-api/src/providers/finviz/models/quote.ts
@@ -36,7 +36,7 @@ export class FinVizQuoteFetcher implements Fetcher<FinVizQuoteQuery, FinVizQuote
 
   async extractData(
     query: FinVizQuoteQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const url = `https://finviz.com/quote.ashx?t=${query.symbol}`;
 
@@ -45,7 +45,7 @@ export class FinVizQuoteFetcher implements Fetcher<FinVizQuoteQuery, FinVizQuote
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
     };
 
-    const html = await makeRequest(url, { headers });
+    await makeRequest(url, { headers });
 
     // Note: This would require HTML parsing in a real implementation
     // For now, we'll return a placeholder indicating scraping is needed

--- a/packages/fin-data-api/src/providers/fmp/models/quote.ts
+++ b/packages/fin-data-api/src/providers/fmp/models/quote.ts
@@ -55,7 +55,7 @@ export class FMPQuoteFetcher implements Fetcher<FMPQuoteQuery, FMPQuoteData> {
     return response;
   }
 
-  transformData(query: FMPQuoteQuery, data: any[]): FMPQuoteData[] {
+  transformData(_query: FMPQuoteQuery, data: any[]): FMPQuoteData[] {
     return data.map((item) =>
       FMPQuoteDataSchema.parse({
         symbol: item.symbol,

--- a/packages/fin-data-api/src/providers/fred/models/series.ts
+++ b/packages/fin-data-api/src/providers/fred/models/series.ts
@@ -85,7 +85,7 @@ export class FREDSeriesFetcher implements Fetcher<FREDSeriesQuery, FREDSeriesDat
     return response.observations;
   }
 
-  transformData(query: FREDSeriesQuery, data: any[]): FREDSeriesData[] {
+  transformData(_query: FREDSeriesQuery, data: any[]): FREDSeriesData[] {
     return data
       .map((item) => ({
         date: item.date,

--- a/packages/fin-data-api/src/providers/government_us/models/datasets.ts
+++ b/packages/fin-data-api/src/providers/government_us/models/datasets.ts
@@ -35,7 +35,7 @@ export class GovernmentUSDatasetFetcher
 
   async extractData(
     query: GovernmentUSDatasetQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const url = `https://catalog.data.gov/api/3/action/package_show?id=${query.dataset_id}`;
 
@@ -48,7 +48,7 @@ export class GovernmentUSDatasetFetcher
     return [response.result];
   }
 
-  transformData(query: GovernmentUSDatasetQuery, data: any[]): GovernmentUSDatasetData[] {
+  transformData(_query: GovernmentUSDatasetQuery, data: any[]): GovernmentUSDatasetData[] {
     return data.map((item) =>
       GovernmentUSDatasetDataSchema.parse({
         title: item.title,

--- a/packages/fin-data-api/src/providers/imf/models/economicData.ts
+++ b/packages/fin-data-api/src/providers/imf/models/economicData.ts
@@ -35,7 +35,7 @@ export class IMFEconomicDataFetcher
 
   async extractData(
     query: IMFEconomicDataQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const baseUrl = 'https://www.imf.org/external/datamapper/api/v1';
     const url = `${baseUrl}/${query.indicator}/${query.country}`;
@@ -68,7 +68,7 @@ export class IMFEconomicDataFetcher
     return results;
   }
 
-  transformData(query: IMFEconomicDataQuery, data: any[]): IMFEconomicDataData[] {
+  transformData(_query: IMFEconomicDataQuery, data: any[]): IMFEconomicDataData[] {
     return data.map((item) => IMFEconomicDataDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/intrinio/models/stockPrice.ts
+++ b/packages/fin-data-api/src/providers/intrinio/models/stockPrice.ts
@@ -76,7 +76,7 @@ export class IntrinioStockPriceFetcher
     return response.stock_prices;
   }
 
-  transformData(query: IntrinioStockPriceQuery, data: any[]): IntrinioStockPriceData[] {
+  transformData(_query: IntrinioStockPriceQuery, data: any[]): IntrinioStockPriceData[] {
     return data.map((item) =>
       IntrinioStockPriceDataSchema.parse({
         date: item.date,

--- a/packages/fin-data-api/src/providers/multpl/models/sp500Multiples.ts
+++ b/packages/fin-data-api/src/providers/multpl/models/sp500Multiples.ts
@@ -46,7 +46,7 @@ export class MultplSP500MultiplesFetcher
 
   async extractData(
     query: MultplSP500MultiplesQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const urlPath = URL_DICT[query.series_name];
     if (!urlPath) {
@@ -60,7 +60,7 @@ export class MultplSP500MultiplesFetcher
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
     };
 
-    const html = await makeRequest(url, { headers });
+    await makeRequest(url, { headers });
 
     // Note: This requires HTML table parsing
     // Placeholder implementation

--- a/packages/fin-data-api/src/providers/nasdaq/models/quote.ts
+++ b/packages/fin-data-api/src/providers/nasdaq/models/quote.ts
@@ -34,7 +34,7 @@ export class NasdaqQuoteFetcher implements Fetcher<NasdaqQuoteQuery, NasdaqQuote
 
   async extractData(
     query: NasdaqQuoteQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const url = `https://api.nasdaq.com/api/quote/${query.symbol}/info?assetclass=stocks`;
 

--- a/packages/fin-data-api/src/providers/oecd/models/economicData.ts
+++ b/packages/fin-data-api/src/providers/oecd/models/economicData.ts
@@ -35,7 +35,7 @@ export class OECDEconomicDataFetcher
 
   async extractData(
     query: OECDEconomicDataQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const params: string[] = [];
 
@@ -86,7 +86,7 @@ export class OECDEconomicDataFetcher
     return results;
   }
 
-  transformData(query: OECDEconomicDataQuery, data: any[]): OECDEconomicDataData[] {
+  transformData(_query: OECDEconomicDataQuery, data: any[]): OECDEconomicDataData[] {
     return data.map((item) => OECDEconomicDataDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/sec/models/filings.ts
+++ b/packages/fin-data-api/src/providers/sec/models/filings.ts
@@ -41,7 +41,7 @@ export class SECFilingsFetcher implements Fetcher<SECFilingsQuery, SECFilingsDat
 
   async extractData(
     query: SECFilingsQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     // First, get CIK from symbol if needed
     let cik = query.cik;
@@ -103,7 +103,7 @@ export class SECFilingsFetcher implements Fetcher<SECFilingsQuery, SECFilingsDat
     return filings;
   }
 
-  transformData(query: SECFilingsQuery, data: any[]): SECFilingsData[] {
+  transformData(_query: SECFilingsQuery, data: any[]): SECFilingsData[] {
     return data.map((item) => SECFilingsDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/seeking_alpha/models/calendarEarnings.ts
+++ b/packages/fin-data-api/src/providers/seeking_alpha/models/calendarEarnings.ts
@@ -4,7 +4,7 @@
  */
 
 import { z } from 'zod';
-import { Fetcher, QueryParams, Data } from '../../../types/base';
+import { Fetcher } from '../../../types/base';
 import { HEADERS } from '../utils/helpers';
 import { makeRequest } from '../../../utils/http';
 import { getDateArray, formatDate, addDays, today } from '../../../utils/dates';
@@ -74,7 +74,7 @@ export class SACalendarEarningsFetcher
    */
   async extractData(
     query: SACalendarEarningsQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const results: any[] = [];
 
@@ -142,7 +142,7 @@ export class SACalendarEarningsFetcher
   /**
    * Transform raw data to structured format
    */
-  transformData(query: SACalendarEarningsQuery, data: any[]): SACalendarEarningsData[] {
+  transformData(_query: SACalendarEarningsQuery, data: any[]): SACalendarEarningsData[] {
     const transformedData: SACalendarEarningsData[] = [];
 
     // Sort by release date

--- a/packages/fin-data-api/src/providers/seeking_alpha/utils/helpers.ts
+++ b/packages/fin-data-api/src/providers/seeking_alpha/utils/helpers.ts
@@ -4,7 +4,6 @@
  */
 
 import { makeRequest } from '../../../utils/http';
-import { dateRange } from '../../../utils/dates';
 
 export const HEADERS = {
   'User-Agent':

--- a/packages/fin-data-api/src/providers/stockgrid/models/optionsFlow.ts
+++ b/packages/fin-data-api/src/providers/stockgrid/models/optionsFlow.ts
@@ -63,7 +63,7 @@ export class StockgridOptionsFlowFetcher
     return response;
   }
 
-  transformData(query: StockgridOptionsFlowQuery, data: any[]): StockgridOptionsFlowData[] {
+  transformData(_query: StockgridOptionsFlowQuery, data: any[]): StockgridOptionsFlowData[] {
     return data.map((item) =>
       StockgridOptionsFlowDataSchema.parse({
         timestamp: item.timestamp || item.time,

--- a/packages/fin-data-api/src/providers/tiingo/models/stockPrice.ts
+++ b/packages/fin-data-api/src/providers/tiingo/models/stockPrice.ts
@@ -89,7 +89,7 @@ export class TiingoStockPriceFetcher
     return response;
   }
 
-  transformData(query: TiingoStockPriceQuery, data: any[]): TiingoStockPriceData[] {
+  transformData(_query: TiingoStockPriceQuery, data: any[]): TiingoStockPriceData[] {
     return data.map((item) =>
       TiingoStockPriceDataSchema.parse({
         date: item.date.split('T')[0],

--- a/packages/fin-data-api/src/providers/tmx/models/quote.ts
+++ b/packages/fin-data-api/src/providers/tmx/models/quote.ts
@@ -5,7 +5,6 @@
 
 import { z } from 'zod';
 import { Fetcher } from '../../../types/base';
-import { makeRequest } from '../../../utils/http';
 
 export const TMXQuoteQuerySchema = z.object({
   symbol: z.string().describe('Stock symbol'),
@@ -35,15 +34,8 @@ export class TMXQuoteFetcher implements Fetcher<TMXQuoteQuery, TMXQuoteData> {
 
   async extractData(
     query: TMXQuoteQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
-    const url = `https://www.tmx.com/quote/${query.symbol}`;
-
-    const headers = {
-      'User-Agent':
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-    };
-
     // Note: TMX requires web scraping
     // Placeholder implementation
     return [
@@ -59,7 +51,7 @@ export class TMXQuoteFetcher implements Fetcher<TMXQuoteQuery, TMXQuoteData> {
     ];
   }
 
-  transformData(query: TMXQuoteQuery, data: any[]): TMXQuoteData[] {
+  transformData(_query: TMXQuoteQuery, data: any[]): TMXQuoteData[] {
     return data.map((item) => TMXQuoteDataSchema.parse(item));
   }
 }

--- a/packages/fin-data-api/src/providers/tradier/models/quote.ts
+++ b/packages/fin-data-api/src/providers/tradier/models/quote.ts
@@ -66,7 +66,7 @@ export class TradierQuoteFetcher implements Fetcher<TradierQuoteQuery, TradierQu
     return quotes;
   }
 
-  transformData(query: TradierQuoteQuery, data: any[]): TradierQuoteData[] {
+  transformData(_query: TradierQuoteQuery, data: any[]): TradierQuoteData[] {
     return data.map((item) =>
       TradierQuoteDataSchema.parse({
         symbol: item.symbol,

--- a/packages/fin-data-api/src/providers/wsj/models/marketMovers.ts
+++ b/packages/fin-data-api/src/providers/wsj/models/marketMovers.ts
@@ -34,7 +34,7 @@ export class WSJMarketMoversFetcher
 
   async extractData(
     query: WSJMarketMoversQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const typeMap: Record<string, string> = {
       gainers: 'gainers',
@@ -49,7 +49,7 @@ export class WSJMarketMoversFetcher
         'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
     };
 
-    const html = await makeRequest(url, { headers });
+    await makeRequest(url, { headers });
 
     // Note: This requires HTML scraping - placeholder implementation
     return [
@@ -65,7 +65,7 @@ export class WSJMarketMoversFetcher
     ].slice(0, query.limit);
   }
 
-  transformData(query: WSJMarketMoversQuery, data: any[]): WSJMarketMoversData[] {
+  transformData(_query: WSJMarketMoversQuery, data: any[]): WSJMarketMoversData[] {
     return data.map((item) =>
       WSJMarketMoversDataSchema.parse({
         symbol: item.symbol,

--- a/packages/fin-data-api/src/providers/yfinance/models/quote.ts
+++ b/packages/fin-data-api/src/providers/yfinance/models/quote.ts
@@ -41,7 +41,7 @@ export class YFinanceQuoteFetcher implements Fetcher<YFinanceQuoteQuery, YFinanc
 
   async extractData(
     query: YFinanceQuoteQuery,
-    credentials?: Record<string, string>
+    _credentials?: Record<string, string>
   ): Promise<any[]> {
     const symbols = query.symbol.split(',').map((s) => s.trim());
     const url = `https://query2.finance.yahoo.com/v7/finance/quote?symbols=${symbols.join(',')}`;
@@ -60,7 +60,7 @@ export class YFinanceQuoteFetcher implements Fetcher<YFinanceQuoteQuery, YFinanc
     return response.quoteResponse.result;
   }
 
-  transformData(query: YFinanceQuoteQuery, data: any[]): YFinanceQuoteData[] {
+  transformData(_query: YFinanceQuoteQuery, data: any[]): YFinanceQuoteData[] {
     return data.map((item) =>
       YFinanceQuoteDataSchema.parse({
         symbol: item.symbol,

--- a/packages/fin-data-api/src/utils/dates.ts
+++ b/packages/fin-data-api/src/utils/dates.ts
@@ -79,6 +79,15 @@ export function subtractDays(date: Date, days: number): Date {
 }
 
 /**
+ * Add years to a date
+ */
+export function addYears(date: Date, years: number): Date {
+  const result = new Date(date);
+  result.setFullYear(result.getFullYear() + years);
+  return result;
+}
+
+/**
  * Get the number of days between two dates
  */
 export function daysBetween(startDate: Date, endDate: Date): number {


### PR DESCRIPTION
## Summary
This PR performs code cleanup across the financial data API codebase by removing unused imports and marking unused function parameters with underscore prefixes to comply with TypeScript/linting standards.

## Key Changes
- **Removed unused imports**: Eliminated `makeRequest` imports from multiple provider files where they were not being used (FamaFrench, TMX, FederalReserve, FINRA)
- **Removed unused type imports**: Cleaned up unused `QueryParams` and `Data` type imports from several provider modules
- **Marked unused parameters**: Prefixed unused function parameters with underscore (e.g., `query` → `_query`, `credentials` → `_credentials`) across multiple fetcher classes and API endpoints
- **Removed unused variables**: Deleted unused variable declarations like `baseUrl`, `freq`, `url`, `series`, and `html` assignments that were not referenced
- **Added utility function**: Implemented `addYears()` date utility function in `dates.ts` for date manipulation
- **Fixed type annotations**: Added explicit return type annotation to `generateOpenAPISpec()` function
- **Added explicit type annotations**: Added `Router` type annotation to router variable declarations
- **Updated dependency versions**: Changed `zod` and `zod-to-json-schema` from caret ranges to exact versions in package.json
- **Fixed HTTP request handling**: Changed `body` parameter to `data` in BLS series fetcher to match the makeRequest API

## Implementation Details
- The underscore prefix convention (`_paramName`) is a TypeScript best practice for indicating intentionally unused parameters, preventing linter warnings
- Unused imports were identified across provider implementations for Fama-French, TMX, Federal Reserve, and FINRA data sources
- The cleanup maintains all functional behavior while improving code quality and reducing technical debt

https://claude.ai/code/session_01KjRA4zzHihC8kKgbfPouCy