### PR TITLE
Transition web app to Cloudflare Workers (vinext)

### DIFF
--- a/apps/ai-broker-web/app/api/cron/README.md
+++ b/apps/ai-broker-web/app/api/cron/README.md
@@ -1,33 +1,34 @@
-# Vercel Cron Jobs
+# Cloudflare Worker Cron Jobs
 
-This directory contains cron job endpoints that are automatically triggered by Vercel's cron scheduler.
+This directory contains cron job endpoints that are triggered by Cloudflare Workers scheduled events and routed through `apps/ai-broker-web/worker/index.ts`.
 
 ## Setup
 
 ### 1. Environment Variables
 
-Add the following to your Vercel project environment variables:
+Set the shared cron secret as a Cloudflare Worker secret:
 
 ```bash
-CRON_SECRET=your_random_secret_here
+wrangler secret put CRON_SECRET
 ```
 
-Generate a secure random string for the CRON_SECRET:
+Generate a secure random string for `CRON_SECRET`:
+
 ```bash
 openssl rand -base64 32
 ```
 
-### 2. Vercel Configuration
+### 2. Cloudflare Configuration
 
-The cron jobs are configured in [vercel.json](../../../vercel.json) at the project root.
+Cron schedules are configured in `apps/ai-broker-web/wrangler.jsonc` under `triggers.crons`. The Worker `scheduled` handler maps each cron expression to the matching API route and forwards `Authorization: Bearer <CRON_SECRET>`.
 
 ## Available Cron Jobs
 
 ### `/api/cron/sync-markets` - Polymarket Data Sync
 
-**Schedule:** Every 15 minutes (`*/15 * * * *`)
+**Schedule:** Daily at 00:00 UTC (`0 0 * * *`)
 
-**Purpose:** Incrementally syncs the top 1000 high volume Polymarket prediction markets
+**Purpose:** Incrementally syncs the top 1000 high volume Polymarket prediction markets.
 
 **What it does:**
 - Fetches the top 1000 markets sorted by 24h volume
@@ -38,38 +39,37 @@ The cron jobs are configured in [vercel.json](../../../vercel.json) at the proje
 
 **Features:**
 - Non-destructive: Updates existing markets without deleting
-- Batch processing: Processes price history (batches of 50) and holders (batches of 20)
+- Batch processing: Processes price history and holders in batches
 - Error resilient: Continues even if individual markets fail
 - Automatic categorization: Assigns categories (Politics, Sports, Crypto, etc.) and subcategories
-- Rate limit protection: 2-second delays between holder batches
+- Rate limit protection between holder batches
 
 ### `/api/cron/refresh-quotes` - Stock Quote Cache Refresh
 
-**Schedule:** Every 5 minutes (`*/5 * * * *`)
+**Schedule:** Daily at 00:15 UTC (`15 0 * * *`)
 
-**Purpose:** Refreshes stock quotes for ~35 popular symbols to keep cache fresh
+**Purpose:** Refreshes stock quotes for popular symbols to keep cache fresh.
 
 **What it does:**
 - Fetches real-time quotes for popular stocks (AAPL, MSFT, GOOGL, SPY, etc.)
 - Updates quote cache with fresh data
 - Ensures frequently accessed stocks have up-to-date prices
-- Cache TTL: 5 minutes
+- Bypasses stale cache to ensure latest prices
 
 **Features:**
-- Fast execution: ~2-5 seconds typical
-- Popular symbols: Tech giants, major ETFs, financials, and more
-- Force fresh data: Bypasses cache to ensure latest prices
-- Multiple sources: Uses unified quote service with fallback providers
+- Fast execution: typically a few seconds
+- Popular symbols: tech giants, major ETFs, financials, and more
+- Multiple sources: uses unified quote service with fallback providers
 
 ### `/api/cron/sync-polymarket` - Leaders and Categories
 
 **Schedule:** Not yet configured (manual trigger only)
 
-**Purpose:** Syncs Polymarket leaderboard and category data
+**Purpose:** Syncs Polymarket leaderboard and category data.
 
 ## Testing Locally
 
-You can test cron jobs locally using curl:
+Run the vinext dev server and call cron routes with `curl`:
 
 ```bash
 # With authentication (requires valid CRON_SECRET)
@@ -79,11 +79,17 @@ curl -H "Authorization: Bearer your_cron_secret_here" http://localhost:3000/api/
 curl -H "Cookie: your_session_cookie" http://localhost:3000/api/cron/sync-markets
 ```
 
+You can also verify configured schedules with Wrangler:
+
+```bash
+wrangler dev --test-scheduled
+```
+
 ## Monitoring
 
-View cron job logs in:
-- **Vercel Dashboard:** Go to your project → Deployments → Select deployment → Functions → Select function
-- **Real-time logs:** Use `vercel logs` CLI command
+View cron job logs with Cloudflare Workers observability:
+- **Cloudflare Dashboard:** Workers & Pages → `ai-broker-investing-agent` → Logs / Observability
+- **CLI tailing:** `wrangler tail ai-broker-investing-agent`
 
 ## Response Format
 
@@ -107,6 +113,7 @@ All cron jobs return a consistent JSON response:
 ## Error Handling
 
 If a cron job fails:
+
 ```json
 {
   "success": false,
@@ -119,41 +126,30 @@ If a cron job fails:
 ## Security
 
 - All cron endpoints require either:
-  - Valid `Authorization: Bearer <CRON_SECRET>` header (for automated jobs)
-  - Valid user session (for manual triggers)
-- Never commit CRON_SECRET to version control
-- Rotate CRON_SECRET regularly
+  - Valid `Authorization: Bearer <CRON_SECRET>` header for scheduled jobs
+  - Valid user session for manual triggers
+- Never commit `CRON_SECRET` to version control
+- Rotate `CRON_SECRET` regularly
 
-## Limitations
+## Cloudflare Worker Notes
 
-- **Vercel Free/Hobby:** Cron jobs are not available
-- **Vercel Pro:** Up to 2 cron jobs
-- **Vercel Enterprise:** Unlimited cron jobs
-- **Timeout:** Max execution time is 300 seconds (5 minutes) on Pro
-- **Concurrency:** Cron jobs don't run concurrently by default
+- Scheduled events run in the Worker runtime and are dispatched through the vinext App Router handler.
+- Keep each scheduled route within Cloudflare Worker CPU/runtime limits for your plan.
+- If a job needs additional bindings, add them to `wrangler.jsonc` and regenerate types with `npm run cf-typegen`.
 
 ## Adding New Cron Jobs
 
-1. Create a new route handler in this directory (e.g., `sync-example/route.ts`)
-2. Implement authentication check using CRON_SECRET pattern
-3. Add the endpoint to [vercel.json](../../../vercel.json):
-   ```json
-   {
-     "crons": [
-       {
-         "path": "/api/cron/sync-example",
-         "schedule": "0 * * * *"
-       }
-     ]
-   }
-   ```
-4. Deploy to Vercel
+1. Create a new route handler in this directory (for example, `sync-example/route.ts`).
+2. Implement authentication using the existing `CRON_SECRET` pattern.
+3. Add the cron expression to `triggers.crons` in `apps/ai-broker-web/wrangler.jsonc`.
+4. Add the expression-to-route mapping in `apps/ai-broker-web/worker/index.ts`.
+5. Deploy with `npm run deploy`.
 
 ## Cron Schedule Format
 
 The schedule uses standard cron syntax:
 
-```
+```text
 ┌───────────── minute (0 - 59)
 │ ┌───────────── hour (0 - 23)
 │ │ ┌───────────── day of month (1 - 31)
@@ -166,5 +162,5 @@ The schedule uses standard cron syntax:
 Examples:
 - `*/15 * * * *` - Every 15 minutes
 - `0 * * * *` - Every hour
-- `0 0 * * *` - Every day at midnight
+- `0 0 * * *` - Every day at midnight UTC
 - `0 */6 * * *` - Every 6 hours

--- a/apps/ai-broker-web/cloudflare-env.d.ts
+++ b/apps/ai-broker-web/cloudflare-env.d.ts
@@ -33,10 +33,10 @@ declare module "cloudflare:email" {
 
 /**
  * Resolved by the vinext Vite plugin to this project's App Router request
- * handler at build time; declared here so the `vinext/server/fetch-handler`
- * re-export type-checks in worker/index.ts.
+ * handler at build time; declared here so the `vinext/server/app-router-entry`
+ * import type-checks in worker/index.ts.
  */
-declare module "virtual:vinext-worker-entry" {
+declare module "vinext/server/app-router-entry" {
   const handler: {
     fetch(
       request: Request,

--- a/apps/ai-broker-web/tsconfig.json
+++ b/apps/ai-broker-web/tsconfig.json
@@ -10,6 +10,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "incremental": true,
+    "ignoreDeprecations": "6.0",
     "types": [
       "vite/client",
       "vinext/types"

--- a/apps/ai-broker-web/vite.config.ts
+++ b/apps/ai-broker-web/vite.config.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,6 +18,50 @@ const require = createRequire(import.meta.url);
 const entitiesEscape = require.resolve("entities/escape");
 
 const investingSrc = path.resolve(monorepoRoot, "packages/investing/src");
+const fumadocsPlugin = await mdx(mdxConfig);
+
+/**
+ * Fumadocs emits JSON collection imports with query strings. In vinext/RSC
+ * builds those IDs can bypass Vite's standard JSON plugin, so load the raw
+ * JSON early and wrap any remaining JSON payload as an ES module after the
+ * Fumadocs transform. This mirrors the Cloudflare vinext template and keeps
+ * docs generation compatible with Workers builds.
+ */
+function fumadocsJsonLoad(): Plugin {
+  return {
+    name: "fumadocs-json-load",
+    enforce: "pre",
+    resolveId(id) {
+      if (id.match(/\.json\?.*collection=/)) return id;
+      return null;
+    },
+    load(id) {
+      if (!id.match(/\.json\?.*collection=/)) return null;
+      const filePath = id.split("?")[0];
+      try {
+        return { code: readFileSync(filePath, "utf8"), map: null };
+      } catch {
+        return { code: "{}", map: null };
+      }
+    },
+  };
+}
+
+function fumadocsJsonWrap(): Plugin {
+  return {
+    name: "fumadocs-json-wrap",
+    transform(code, id) {
+      if (!id.match(/\.json\?.*collection=/)) return null;
+      const trimmed = code.trim();
+      if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+      try {
+        return { code: `export default ${JSON.stringify(JSON.parse(trimmed))}`, map: null };
+      } catch {
+        return null;
+      }
+    },
+  };
+}
 
 /**
  * `investing/stocks` has a server entry (full ticker dataset) and a trimmed
@@ -40,10 +85,18 @@ function investingStocksEntry(): Plugin {
 }
 
 export default defineConfig({
+  // Polyfill CJS globals used by a few Node-oriented dependencies when they
+  // are bundled into the Cloudflare Workers runtime.
+  define: {
+    __filename: JSON.stringify("/"),
+    __dirname: JSON.stringify("/"),
+  },
   plugins: [
     investingStocksEntry(),
+    fumadocsJsonLoad(),
     // Generates `.source/*` from source.config.ts and compiles content/docs.
-    await mdx(mdxConfig),
+    fumadocsPlugin,
+    fumadocsJsonWrap(),
     vinext({
       // Page-level ISR served straight from the Cloudflare edge cache, so
       // there is no namespace to provision. Add

--- a/apps/ai-broker-web/worker/index.ts
+++ b/apps/ai-broker-web/worker/index.ts
@@ -1,14 +1,14 @@
 /**
  * Cloudflare Workers entrypoint (`main` in wrangler.jsonc).
  *
- * vinext builds the request handler; this wrapper only adds cron trigger
- * routing (replacing vercel.json crons): each schedule in wrangler.jsonc
- * `triggers.crons` is mapped to a Next.js cron API route and dispatched
- * through the same handler with the CRON_SECRET bearer token the routes
- * already expect.
+ * The core request handler comes from vinext's App Router Worker entry. This
+ * wrapper follows the vinext Cloudflare template while preserving this app's
+ * scheduled cron routing: every schedule in wrangler.jsonc `triggers.crons` is
+ * mapped to a Next.js API route and dispatched through the same handler with
+ * the CRON_SECRET bearer token the routes already expect.
  */
 import { env as workerEnv } from "cloudflare:workers";
-import handler from "vinext/server/fetch-handler";
+import handler from "vinext/server/app-router-entry";
 
 /**
  * `packages/investing` runs both on Workers and in plain Node scripts, so it
@@ -23,7 +23,9 @@ const CRON_ROUTES: Record<string, string> = {
 };
 
 export default {
-  fetch: handler.fetch,
+  fetch(request: Request, env: CloudflareEnv, ctx: import("@cloudflare/workers-types").ExecutionContext) {
+    return handler.fetch(request, env, ctx);
+  },
 
   async scheduled(
     controller: { cron: string },
@@ -38,7 +40,7 @@ export default {
     const origin = env.NEXT_PUBLIC_APP_URL || "https://self.internal";
     const headers: Record<string, string> = {};
     if (env.CRON_SECRET) {
-      headers["authorization"] = `Bearer ${env.CRON_SECRET}`;
+      headers.authorization = `Bearer ${env.CRON_SECRET}`;
     }
     ctx.waitUntil(
       handler


### PR DESCRIPTION
### Motivation

- Replace the Vercel-focused runtime with a Cloudflare Workers deployment using the vinext template to run the Next.js App Router on Workers and scheduled events for cron jobs.
- Ensure Fumadocs JSON collections and other doc assets continue to build correctly under the Workers/RSC build path.
- Make the Worker entry and types compatible with vinext's App Router entry while preserving existing cron route dispatch and secrets handling.
- Silence an upcoming TypeScript deprecation warning and add small runtime polyfills for CJS globals required when bundling to Workers.

### Description

- Updated `apps/ai-broker-web/vite.config.ts` to polyfill CJS globals, initialize the `fumadocs` plugin early, and add `fumadocsJsonLoad` and `fumadocsJsonWrap` Vite plugins to load/wrap Fumadocs JSON collection imports for Worker-friendly builds.
- Replaced the Worker wrapper to use vinext's App Router entry by changing `apps/ai-broker-web/worker/index.ts` to import `vinext/server/app-router-entry`, forward `fetch(request, env, ctx)` to the handler, and preserve the `scheduled` mapping that posts `Authorization: Bearer <CRON_SECRET>` to internal cron API routes.
- Adjusted ambient module typing in `apps/ai-broker-web/cloudflare-env.d.ts` to declare the `vinext/server/app-router-entry` module and updated comments accordingly.
- Added `ignoreDeprecations` to `apps/ai-broker-web/tsconfig.json` to suppress the TypeScript 7.0 `baseUrl` deprecation notice and updated cron docs at `apps/ai-broker-web/app/api/cron/README.md` to document Wrangler secrets, scheduled events, local testing, and Cloudflare observability.

### Testing

- Ran `python3 -m json.tool apps/ai-broker-web/tsconfig.json` which passed and confirmed valid JSON.
- Ran `bun run --filter ai-broker-web type-check` which failed because dev dependencies were not installed and TypeScript could not find `vinext/types` and `vite/client` (environment missing `node_modules`).
- Attempted `bun install` which failed due to network/registry 403 errors preventing dependency installation, so full type-check/build tests were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8c04747e60832db013a0cb6a870ada)