### PR TITLE
Move Cloudflare and Wrangler to production dependencies

### DIFF
--- a/apps/ai-broker-web/package.json
+++ b/apps/ai-broker-web/package.json
@@ -73,6 +73,7 @@
     "@types/bun": "^1.3.9",
     "@types/dompurify": "^3.2.0",
     "@types/marked": "^6.0.0",
+    "@vinext/cloudflare": "1.0.0-beta.5",
     "autoprefixer": "^10.4.24",
     "axios": "^1.13.5",
     "better-auth": "^1.4.18",
@@ -144,6 +145,7 @@
     "uuid": "13.0.0",
     "vaul": "^1.1.2",
     "vinext": "1.0.0-beta.5",
+    "wrangler": "^4.24.0",
     "xgboost_node": "^0.4.2",
     "yahoo-finance2": "^3.13.0",
     "zod": "4.3.6"
@@ -158,7 +160,6 @@
     "@types/react": "^19.2.13",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.182.0",
-    "@vinext/cloudflare": "1.0.0-beta.5",
     "@vitejs/plugin-react": "^6.0.5",
     "@vitejs/plugin-rsc": "^0.5.34",
     "concurrently": "^9.2.1",
@@ -170,8 +171,7 @@
     "typescript": "^5.9.3",
     "vite": "^8.2.1",
     "vite-plugin-dts": "^4.5.4",
-    "wait-on": "^9.0.3",
-    "wrangler": "^4.24.0"
+    "wait-on": "^9.0.3"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
Reorganized package dependencies to move Cloudflare-related packages from devDependencies to dependencies, reflecting their role in the production build and runtime.

## Key Changes
- Moved `@vinext/cloudflare` (1.0.0-beta.5) from devDependencies to dependencies
- Moved `wrangler` (^4.24.0) from devDependencies to dependencies
- These packages are now properly classified as production dependencies rather than development-only

## Rationale
This change ensures that Cloudflare integration and Wrangler tooling are available in production environments, as they appear to be required for the application's runtime functionality rather than just build-time tooling.

https://claude.ai/code/session_017RUsMzRfadi8eW1b23WZoy