### PR TITLE
Add wrangler as a root devDependency to fix Workers Build deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "devDependencies": {
     "turbo": "^2.5.8",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "wrangler": "^4.24.0"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Cloudflare Workers Builds runs `npx wrangler deploy` from the repo root, but wrangler was only declared under apps/ai-broker-web, so npx couldn't resolve it and the deploy step failed with "wrangler: not found" even though the build step succeeded.