### PR TITLE
Fix stock historical API 404s and auth get-session connection errors

### DIFF
--- a/apps/ai-broker-web/lib/auth-client.ts
+++ b/apps/ai-broker-web/lib/auth-client.ts
@@ -1,8 +1,13 @@
 import { createAuthClient } from "better-auth/react";
 import { siweClient } from "better-auth/client/plugins";
 
+// Only pass an explicit baseURL when one is configured. Falling back to a
+// hardcoded "http://localhost:3000" breaks auth requests whenever the app is
+// served from anywhere else (preview URLs, deployed environments, or a dev
+// server on a different port) — better-auth's client defaults to the
+// current page origin when baseURL is omitted, which is what we want here.
 export const authClient = createAuthClient({
-  baseURL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+  baseURL: process.env.NEXT_PUBLIC_APP_URL,
   plugins: [siweClient()],
 });
 

--- a/packages/investing/src/stocks/finnhub-utils.ts
+++ b/packages/investing/src/stocks/finnhub-utils.ts
@@ -85,6 +85,25 @@ export function mapIntervalToAlpacaTimeframe(interval: string): string {
 }
 
 /**
+ * Map interval to Yahoo Finance's historical() interval format.
+ * Yahoo's historical endpoint only supports daily/weekly/monthly bars, so
+ * intraday intervals (1m/5m/15m/30m/60m) have no equivalent and return null.
+ */
+export function mapIntervalToYahoo(
+  interval?: string,
+): "1d" | "1wk" | "1mo" | null {
+  const mapping: Record<string, "1d" | "1wk" | "1mo"> = {
+    D: "1d",
+    W: "1wk",
+    M: "1mo",
+    "1d": "1d",
+    "1wk": "1wk",
+    "1mo": "1mo",
+  };
+  return mapping[interval || "1d"] || null;
+}
+
+/**
  * Get Alpaca API credentials from environment
  */
 export function getAlpacaCredentials(): {

--- a/packages/investing/src/stocks/finnhub-wrapper.ts
+++ b/packages/investing/src/stocks/finnhub-wrapper.ts
@@ -2,6 +2,7 @@
 // Uses Finnhub as primary source with Alpaca API as fallback for historical data
 
 import { createAlpacaClient } from "../alpaca/client";
+import { yahooFinance } from "./yahoo-finance-wrapper";
 import type {
   HistoricalDataOptions,
   QuoteOptions,
@@ -25,6 +26,7 @@ import {
   toUnixTimestamp,
   finnhubFetch,
   mapIntervalToAlpacaTimeframe,
+  mapIntervalToYahoo,
   getAlpacaCredentials,
   formatDateRFC3339,
   formatDateYYYYMMDD,
@@ -148,14 +150,65 @@ export class FinnhubWrapper {
       );
     }
 
+    // Final fallback: Yahoo Finance requires no API key, so this keeps
+    // historical data working even when Finnhub/Alpaca aren't configured.
+    // Yahoo's historical() endpoint only supports daily/weekly/monthly bars.
+    const yahooInterval = mapIntervalToYahoo(interval);
+    if (yahooInterval) {
+      try {
+        console.log(`[Yahoo] Attempting to fetch historical data for ${symbol}...`);
+        const result = await yahooFinance.getHistorical(symbol, {
+          period1,
+          period2,
+          interval: yahooInterval,
+        });
+
+        if (result.success && result.data && result.data.length > 0) {
+          const quotes: FinnhubQuoteData[] = result.data.map((bar: any) => ({
+            date: new Date(bar.date),
+            open: bar.open,
+            high: bar.high,
+            low: bar.low,
+            close: bar.close,
+            volume: bar.volume,
+          }));
+
+          console.log(
+            `[Yahoo] Successfully fetched ${quotes.length} bars for ${symbol}`,
+          );
+
+          return {
+            success: true,
+            symbol,
+            source: "yahoo",
+            data: {
+              quotes,
+              meta: {
+                symbol,
+                exchangeName: "US",
+                regularMarketPrice: quotes[quotes.length - 1].close,
+              },
+            },
+            meta: {
+              symbol,
+              regularMarketPrice: quotes[quotes.length - 1].close,
+            },
+          };
+        }
+        console.log(`[Yahoo] Returned no data for ${symbol}`);
+      } catch (yahooError: any) {
+        console.log(`[Yahoo] API fallback failed for ${symbol}: ${yahooError.message}`);
+      }
+    }
+
     console.error(
-      `[Historical] Failed to fetch data for ${symbol} from both Finnhub and Alpaca`,
+      `[Historical] Failed to fetch data for ${symbol} from Finnhub, Alpaca, and Yahoo Finance`,
     );
 
     return {
       success: false,
       error:
-        "Failed to fetch historical data from both Finnhub and Alpaca. Please check API credentials are configured.",
+        "Failed to fetch historical data from Finnhub, Alpaca, and Yahoo Finance.",
     };
   }
 


### PR DESCRIPTION
## Summary

The browser console showed repeated failures for:
- `GET /api/stocks/historical/AAPL?range=...` → 404
- `GET localhost:3000/api/auth/get-session` → `net::ERR_CONNECTION_REFUSED`

Root causes and fixes:

- **Historical stock data 404s**: `/api/stocks/historical/[symbol]` only tries Finnhub and Alpaca, both of which require API keys (`FINNHUB_API_KEY`, `ALPACA_API_KEY`/`ALPACA_SECRET`). When neither is configured, the route always returns 404. Added Yahoo Finance (`yahoo-finance2`, no API key required) as a final fallback tier in `FinnhubWrapper.getHistoricalData`, so daily/weekly/monthly historical data still loads without any credentials configured.

- **Auth `get-session` connection refused**: `lib/auth-client.ts` hardcoded `baseURL: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"`. Whenever the app is served from anywhere other than literally `localhost:3000` for the visiting browser (preview URLs, deployed environments, a dev server on another port), the client tries to hit `http://localhost:3000` directly and fails with `ERR_CONNECTION_REFUSED`. Removed the hardcoded fallback — better-auth's client defaults to the current page origin when `baseURL` is omitted, which is the correct behavior here.

## Changes

- `packages/investing/src/stocks/finnhub-utils.ts`: add `mapIntervalToYahoo` helper mapping Finnhub-style intervals to Yahoo's `1d`/`1wk`/`1mo` (returns `null` for intraday intervals Yahoo's `historical()` doesn't support).
- `packages/investing/src/stocks/finnhub-wrapper.ts`: try Yahoo Finance as a third fallback after Finnhub and Alpaca both fail/are unconfigured.
- `apps/ai-broker-web/lib/auth-client.ts`: drop the hardcoded `localhost:3000` fallback for the auth client's `baseURL`.

## Test plan

- [ ] Manually verify `/api/stocks/historical/AAPL?range=1y&interval=1d` returns data with no Finnhub/Alpaca keys configured
- [ ] Manually verify auth session requests hit the current origin instead of `localhost:3000` when the app is served elsewhere
- No local build/typecheck was run — this sandbox has no installed dependencies (`node_modules` absent); changes were reviewed manually against existing types/signatures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T8jwVaUbYwSvTo3vdATtje

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8jwVaUbYwSvTo3vdATtje)_