### PR TITLE
Fix Yahoo Finance historical data errors for partially populated rows

### DIFF
--- a/packages/investing/src/stocks/yahoo-finance-wrapper.ts
+++ b/packages/investing/src/stocks/yahoo-finance-wrapper.ts
@@ -10,6 +10,72 @@ import YahooFinance from "yahoo-finance2";
 const yf = new YahooFinance();
 
 /**
+ * A single row of historical price data, shaped like the rows the deprecated
+ * `yahooFinance.historical()` helper used to return.
+ */
+export interface HistoricalRow {
+  date: Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  adjClose: number;
+  volume: number;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+/**
+ * Convert `chart()` quotes into historical-style rows.
+ *
+ * Yahoo regularly returns rows where only some of the OHLCV fields are
+ * populated (the in-progress session, halted symbols, dividend/split
+ * timestamps). The deprecated `historical()` helper throws on those rows;
+ * here we drop rows with no usable price at all and backfill the remaining
+ * gaps from the fields that are present.
+ */
+export function normalizeChartQuotes(quotes: any[] | undefined): HistoricalRow[] {
+  if (!Array.isArray(quotes)) return [];
+
+  const rows: HistoricalRow[] = [];
+
+  for (const quote of quotes) {
+    if (!quote) continue;
+
+    const date =
+      quote.date instanceof Date ? quote.date : new Date(quote.date as any);
+    if (Number.isNaN(date.getTime())) continue;
+
+    const close = toFiniteNumber(quote.close);
+    const open = toFiniteNumber(quote.open);
+    const high = toFiniteNumber(quote.high);
+    const low = toFiniteNumber(quote.low);
+    const adjClose = toFiniteNumber(quote.adjclose ?? quote.adjClose);
+
+    // Fall back to any price we do have, so a partially filled row is still
+    // usable rather than being dropped entirely.
+    const reference = close ?? open ?? adjClose ?? high ?? low;
+    if (reference === null) continue; // No usable price data in this row
+
+    rows.push({
+      date,
+      open: open ?? reference,
+      high: high ?? Math.max(open ?? reference, close ?? reference),
+      low: low ?? Math.min(open ?? reference, close ?? reference),
+      close: close ?? reference,
+      adjClose: adjClose ?? close ?? reference,
+      volume: toFiniteNumber(quote.volume) ?? 0,
+    });
+  }
+
+  return rows;
+}
+
+/**
  * Yahoo Finance Wrapper Class
  * Provides a comprehensive API for stock market data
  */
@@ -63,6 +129,14 @@ export class YahooFinanceWrapper {
 
   /**
    * Get historical price data
+   *
+   * Implemented on top of `chart()` rather than the deprecated `historical()`
+   * helper. `historical()` throws ("Historical returned a result with SOME
+   * (but not all) null values") whenever Yahoo returns a partially populated
+   * row - which happens regularly for the in-progress trading session, for
+   * halted symbols and around dividend/split timestamps. We normalize those
+   * rows here instead of failing the whole request.
+   *
    * @param symbol - Stock symbol
    * @param options - Historical data options (period1, period2, interval)
    */
@@ -75,23 +149,28 @@ export class YahooFinanceWrapper {
     },
   ) {
     try {
-      const data = await yf.historical(
+      const period1 =
+        options?.period1 ?? new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+      const period2 = options?.period2 ?? new Date();
+      const interval = options?.interval || "1d";
+
+      const chart = await yf.chart(
         symbol,
-        {
-          period1:
-            options?.period1 ||
-            new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
-          period2: options?.period2 || new Date(),
-          interval: options?.interval || "1d",
-        },
+        { period1, period2, interval },
         { validateResult: false },
       );
+
+      const data = normalizeChartQuotes(chart?.quotes);
+
       return {
         success: true,
         data,
       };
     } catch (error: any) {
-      console.error(`Yahoo Finance historical error for ${symbol}:`, error);
+      console.error(
+        `Yahoo Finance historical error for ${symbol}:`,
+        error?.message || error,
+      );
       return {
         success: false,
         error: error.message || "Failed to fetch historical data",

--- a/packages/investing/test/yahoo-historical-normalize.test.ts
+++ b/packages/investing/test/yahoo-historical-normalize.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { normalizeChartQuotes } from "../src/stocks/yahoo-finance-wrapper";
+
+/**
+ * Regression tests for the "Yahoo Finance historical error for WMT" failure.
+ *
+ * yahoo-finance2's deprecated `historical()` helper throws
+ * "Historical returned a result with SOME (but not all) null values" whenever
+ * Yahoo returns a partially populated row. getHistorical() now goes through
+ * `chart()` and normalizes those rows instead.
+ */
+describe("normalizeChartQuotes", () => {
+  const fullRow = {
+    date: new Date("2026-09-02T13:30:00Z"),
+    open: 100,
+    high: 105,
+    low: 99,
+    close: 104,
+    adjclose: 103.5,
+    volume: 1_000_000,
+  };
+
+  it("returns an empty array for missing or non-array input", () => {
+    expect(normalizeChartQuotes(undefined)).toEqual([]);
+    expect(normalizeChartQuotes(null as any)).toEqual([]);
+    expect(normalizeChartQuotes([])).toEqual([]);
+  });
+
+  it("maps a complete row and renames adjclose to adjClose", () => {
+    const [row] = normalizeChartQuotes([fullRow]);
+
+    expect(row).toEqual({
+      date: fullRow.date,
+      open: 100,
+      high: 105,
+      low: 99,
+      close: 104,
+      adjClose: 103.5,
+      volume: 1_000_000,
+    });
+  });
+
+  it("keeps a partially populated row instead of throwing", () => {
+    // The shape that broke WMT: a price but no volume/high/low yet.
+    const rows = normalizeChartQuotes([
+      fullRow,
+      {
+        date: new Date("2026-09-03T13:30:00Z"),
+        open: null,
+        high: null,
+        low: null,
+        close: 106,
+        adjclose: null,
+        volume: null,
+      },
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[1]).toEqual({
+      date: new Date("2026-09-03T13:30:00Z"),
+      open: 106,
+      high: 106,
+      low: 106,
+      close: 106,
+      adjClose: 106,
+      volume: 0,
+    });
+  });
+
+  it("backfills missing high/low from the prices that are present", () => {
+    const [row] = normalizeChartQuotes([
+      {
+        date: new Date("2026-09-03T13:30:00Z"),
+        open: 110,
+        high: null,
+        low: null,
+        close: 104,
+        volume: 5,
+      },
+    ]);
+
+    expect(row.high).toBe(110);
+    expect(row.low).toBe(104);
+    expect(row.adjClose).toBe(104);
+  });
+
+  it("drops rows with no usable price data or an invalid date", () => {
+    const rows = normalizeChartQuotes([
+      fullRow,
+      {
+        date: new Date("2026-09-03T13:30:00Z"),
+        open: null,
+        high: null,
+        low: null,
+        close: null,
+        adjclose: null,
+        volume: null,
+      },
+      { date: "not-a-date", close: 10 },
+      null,
+    ]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].close).toBe(104);
+  });
+
+  it("ignores NaN/Infinity values coming back from the API", () => {
+    const [row] = normalizeChartQuotes([
+      { ...fullRow, volume: Number.NaN, high: Number.POSITIVE_INFINITY },
+    ]);
+
+    expect(row.volume).toBe(0);
+    expect(row.high).toBe(104);
+  });
+
+  it("accepts epoch-style dates", () => {
+    const ts = Date.UTC(2026, 8, 3, 13, 30);
+    const [row] = normalizeChartQuotes([{ ...fullRow, date: ts }]);
+
+    expect(row.date.getTime()).toBe(ts);
+  });
+});


### PR DESCRIPTION
## Summary
Replace the deprecated `yahoo-finance2` `historical()` helper with the `chart()` API and implement row normalization to handle partially populated data rows that previously caused failures.

## Key Changes
- **New `normalizeChartQuotes()` function**: Converts chart API quotes into historical-style rows with intelligent backfilling
  - Drops rows with no usable price data
  - Backfills missing OHLC values from available prices
  - Handles invalid dates and NaN/Infinity values
  - Normalizes field names (e.g., `adjclose` → `adjClose`)
  
- **Updated `getHistorical()` method**: Now uses `chart()` API instead of deprecated `historical()` helper
  - Applies normalization to handle Yahoo's partially populated rows
  - Maintains backward-compatible return type via `HistoricalRow` interface
  
- **New `HistoricalRow` interface**: Defines the shape of normalized historical data rows

## Implementation Details
- Yahoo Finance regularly returns rows where only some OHLCV fields are populated (in-progress sessions, halted symbols, dividend/split timestamps)
- The deprecated `historical()` helper throws an error on these partial rows
- The new implementation gracefully handles these cases by:
  - Using any available price as a reference point for missing values
  - Setting high/low to the max/min of available prices when missing
  - Defaulting volume to 0 when unavailable
  - Filtering out rows with no usable price data entirely
- Includes comprehensive test coverage for edge cases (null values, NaN, invalid dates, epoch timestamps)

https://claude.ai/code/session_01FZ3ekjB69uR5AdbZPEDADf