### PR TITLE
docs: add grab.js.org badge next to Next.js badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     </a>
     <img src="https://img.shields.io/github/last-commit/vtempest/stock-prediction-agent.svg" alt="GitHub last commit" />
     <img src="https://img.shields.io/badge/Next.js-16.0-black" alt="Next.js" />
+    <a href="https://grab.js.org"><img src="https://i.imgur.com/EWze7Ew.png" height="20" alt="grab.js.org" /></a>
 
 </p>
 <p align="center">


### PR DESCRIPTION
## Summary
- Add the grab.js.org badge (linking to https://grab.js.org, same badge asset used in the upstream GRAB-URL repo) next to the Next.js badge in the README's top badge row.

## Test plan
- [x] Rendered badge row reviewed for correct markup/placement (docs-only change, no build/test impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfVS1D8tBMvCsnkP92ThXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01MfVS1D8tBMvCsnkP92ThXc)_