### PR TITLE
Refactor external links and fix auth config for Workers

### DIFF
--- a/apps/ai-broker-web/components/investing/shared/quote-view.tsx
+++ b/apps/ai-broker-web/components/investing/shared/quote-view.tsx
@@ -87,6 +87,63 @@ interface QuoteViewProps {
   tradeSignals?: TradeSignal[]
 }
 
+/**
+ * Off-site destinations for a ticker. Research also carries what used to be the
+ * separate Social and Filings groups — one entry each is not worth its own
+ * section header.
+ */
+type ExternalLink = { name: string; host: string; href: (symbol: string) => string }
+
+const EXTERNAL_LINKS: { brokers: ExternalLink[]; research: ExternalLink[] } = {
+  brokers: [
+    { name: "Robinhood", host: "robinhood.com", href: (s) => `https://robinhood.com/stocks/${s}` },
+    { name: "Webull", host: "webull.com", href: (s) => `https://app.webull.com/stocks/${s}` },
+    {
+      name: "Fidelity",
+      host: "fidelity.com",
+      href: (s) =>
+        `https://digital.fidelity.com/prgw/digital/research/quote/dashboard/summary?symbol=${s}`,
+    },
+  ],
+  research: [
+    { name: "Yahoo Finance", host: "finance.yahoo.com", href: (s) => `https://finance.yahoo.com/quote/${s}` },
+    { name: "TradingView", host: "tradingview.com", href: (s) => `https://www.tradingview.com/symbols/${s}` },
+    { name: "Google Finance", host: "google.com", href: (s) => `https://www.google.com/finance/quote/${s}` },
+    { name: "MarketWatch", host: "marketwatch.com", href: (s) => `https://www.marketwatch.com/investing/stock/${s}` },
+    { name: "Finviz", host: "finviz.com", href: (s) => `https://finviz.com/quote.ashx?t=${s}` },
+    { name: "Stocktwits", host: "stocktwits.com", href: (s) => `https://stocktwits.com/symbol/${s}` },
+    {
+      name: "SEC EDGAR",
+      host: "sec.gov",
+      href: (s) =>
+        `https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&ticker=${s}&type=&dateb=&owner=exclude&count=40`,
+    },
+  ],
+}
+
+/** Google's public favicon service — no key, and it falls back to a generic globe. */
+const faviconUrl = (host: string) =>
+  `https://www.google.com/s2/favicons?domain=${host}&sz=64`
+
+function ExternalLinkItem({ link, symbol }: { link: ExternalLink; symbol: string }) {
+  return (
+    <DropdownMenuItem asChild>
+      <a href={link.href(symbol)} target="_blank" rel="noopener noreferrer">
+        <img
+          src={faviconUrl(link.host)}
+          alt=""
+          aria-hidden="true"
+          width={16}
+          height={16}
+          loading="lazy"
+          className="mr-2 h-4 w-4 rounded-sm"
+        />
+        {link.name}
+      </a>
+    </DropdownMenuItem>
+  )
+}
+
 export function QuoteView({ symbol, showBackButton = true, tradeSignals = [] }: QuoteViewProps) {
   const router = useRouter()
   const { data: session } = useSession()
@@ -503,62 +560,14 @@ export function QuoteView({ symbol, showBackButton = true, tradeSignals = [] }: 
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end">
                   <DropdownMenuLabel>Brokers</DropdownMenuLabel>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://robinhood.com/stocks/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Robinhood
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://app.webull.com/stocks/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Webull
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://digital.fidelity.com/prgw/digital/research/quote/dashboard/summary?symbol=${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Fidelity
-                    </a>
-                  </DropdownMenuItem>
+                  {EXTERNAL_LINKS.brokers.map((link) => (
+                    <ExternalLinkItem key={link.name} link={link} symbol={symbol} />
+                  ))}
                   <DropdownMenuSeparator />
                   <DropdownMenuLabel>Research</DropdownMenuLabel>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://finance.yahoo.com/quote/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Yahoo Finance
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://www.tradingview.com/symbols/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      TradingView
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://www.google.com/finance/quote/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Google Finance
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://www.marketwatch.com/investing/stock/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      MarketWatch
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://finviz.com/quote.ashx?t=${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Finviz
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel>Social</DropdownMenuLabel>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://stocktwits.com/symbol/${symbol}`} target="_blank" rel="noopener noreferrer">
-                      Stocktwits
-                    </a>
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuLabel>Filings</DropdownMenuLabel>
-                  <DropdownMenuItem asChild>
-                    <a href={`https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&ticker=${symbol}&type=&dateb=&owner=exclude&count=40`} target="_blank" rel="noopener noreferrer">
-                      SEC EDGAR
-                    </a>
-                  </DropdownMenuItem>
+                  {EXTERNAL_LINKS.research.map((link) => (
+                    <ExternalLinkItem key={link.name} link={link} symbol={symbol} />
+                  ))}
                 </DropdownMenuContent>
               </DropdownMenu>
               {session?.user && (

--- a/apps/ai-broker-web/lib/auth/index.ts
+++ b/apps/ai-broker-web/lib/auth/index.ts
@@ -13,12 +13,13 @@ import { plans, type Plan } from "../payments/plans";
 import { headers } from "next/headers";
 import { sendEmail, renderEmailLayout, renderEmailButton } from "../email/send-email";
 import { env } from "../../env";
+import { serverEnv } from "../env/runtime";
 
 // Lazy Stripe client initialization to avoid build-time errors
 let _stripeClient: Stripe | null = null
 function getStripeClient() {
   if (!_stripeClient) {
-    _stripeClient = new Stripe(env.STRIPE_SECRET_KEY || 'placeholder', {
+    _stripeClient = new Stripe(serverEnv("STRIPE_SECRET_KEY") || env.STRIPE_SECRET_KEY || 'placeholder', {
       typescript: true
     })
   }
@@ -29,10 +30,52 @@ function getStripeClient() {
 // https://buy.stripe.com/5kQfZgcMng3a6Xebelcs800
 //
 
+/**
+ * Auth configuration resolved from the Worker env (see lib/env/runtime.ts).
+ * Reading `process.env` directly at module scope leaves every one of these
+ * blank on Workers, which is not a visible failure at boot — it only surfaces
+ * later as a 500 from whichever endpoint needed the value.
+ */
+const appUrl = serverEnv("NEXT_PUBLIC_APP_URL") || env.NEXT_PUBLIC_APP_URL || "http://localhost:3000";
+const appDomain =
+  (serverEnv("NEXT_PUBLIC_APP_DOMAIN") || env.NEXT_PUBLIC_APP_DOMAIN || appUrl)
+    .split("//")
+    .pop()
+    ?.split("/")[0] || "localhost:3000";
+const authSecret = serverEnv("BETTER_AUTH_SECRET") || serverEnv("AUTH_SECRET") || env.BETTER_AUTH_SECRET;
+const googleClientId = serverEnv("GOOGLE_CLIENT_ID") || env.GOOGLE_CLIENT_ID;
+const googleClientSecret = serverEnv("GOOGLE_CLIENT_SECRET") || env.GOOGLE_CLIENT_SECRET;
+
+if (!authSecret) {
+  console.error(
+    "BETTER_AUTH_SECRET is not set. Sessions are being signed with a placeholder " +
+      "secret and will not survive a redeploy. Set it with `wrangler secret put BETTER_AUTH_SECRET`.",
+  );
+}
+
+/**
+ * Only register Google when both credentials are present. better-auth keeps a
+ * provider configured with blank credentials in its provider list and then
+ * throws a plain `BetterAuthError` from `createAuthorizationURL`, which
+ * better-call reports as an uninformative 500 on POST /api/auth/sign-in/social.
+ * Leaving the provider out instead produces better-auth's own
+ * "Provider not found" response and logs the reason.
+ */
+const socialProviders = googleClientId && googleClientSecret
+  ? { google: { clientId: googleClientId, clientSecret: googleClientSecret } }
+  : {};
+
+if (!googleClientId || !googleClientSecret) {
+  console.error(
+    "Google sign-in is disabled: GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET are " +
+      "not both set. Set them with `wrangler secret put <NAME>`.",
+  );
+}
+
 export const auth = betterAuth({
-  baseURL: env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+  baseURL: appUrl,
   // basePath: "/api/auth", // better-auth defaults to this, but keeping it explicit if user wants
-  secret: env.BETTER_AUTH_SECRET || process.env.AUTH_SECRET || "your-secret-key",
+  secret: authSecret || "your-secret-key",
   database: drizzleAdapter(db, {
     provider: "sqlite",
     schema: {
@@ -45,20 +88,15 @@ export const auth = betterAuth({
       subscription: schema.subscriptions,
     },
   }),
-  socialProviders: {
-    google: {
-      clientId: env.GOOGLE_CLIENT_ID || "",
-      clientSecret: env.GOOGLE_CLIENT_SECRET || "",
-    }
-  },
+  socialProviders,
   plugins: [
     siwe({
       // Enable anonymous mode so email is not required
       // Users can sign in with just their Ethereum wallet
       anonymous: true,
-      domain: env.NEXT_PUBLIC_APP_DOMAIN?.split("//")[1] || "localhost:3000",
+      domain: appDomain,
       // Extract domain without protocol for email generation
-      emailDomainName: env.NEXT_PUBLIC_APP_URL?.split("//")[1]?.split("/")[0] || "localhost:3000",
+      emailDomainName: appDomain,
       getNonce: async () => {
         // Generate a cryptographically secure random nonce
         return randomBytes(32).toString("hex");
@@ -93,7 +131,7 @@ export const auth = betterAuth({
       get stripeClient() {
         return getStripeClient()
       },
-      stripeWebhookSecret: env.STRIPE_WEBHOOK_SECRET!,
+      stripeWebhookSecret: serverEnv("STRIPE_WEBHOOK_SECRET") || env.STRIPE_WEBHOOK_SECRET!,
       createCustomerOnSignUp: true,
       subscription: {
         enabled: true,
@@ -173,9 +211,7 @@ export const auth = betterAuth({
       });
     },
   },
-  trustedOrigins: [
-    env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
-  ],
+  trustedOrigins: [appUrl],
   session: {
     expiresIn: 60 * 60 * 24 * 60, // 60 days
     updateAge: 60 * 60 * 24 * 3, // 1 day

--- a/apps/ai-broker-web/lib/env/runtime.ts
+++ b/apps/ai-broker-web/lib/env/runtime.ts
@@ -1,0 +1,53 @@
+import { env as workerEnv } from "cloudflare:workers";
+
+/**
+ * Read a server-side variable at request time.
+ *
+ * Secrets set with `wrangler secret put` and the `vars` from wrangler.jsonc are
+ * delivered on the Worker's `env` object. `process.env` only mirrors them under
+ * `nodejs_compat`, and not at all in the Node scripts and build steps that
+ * import the same modules, so the Worker env is the source of truth and
+ * `process.env` (which is what `.env` files and `@t3-oss/env-nextjs` populate
+ * locally) is the fallback.
+ *
+ * Empty strings are treated as "not set" so a blank secret never looks like a
+ * real value to a call site that only checks for undefined.
+ */
+export function serverEnv(name: string): string | undefined {
+  for (const source of [readWorkerEnv, readGlobalEnv, readProcessEnv]) {
+    const value = source(name);
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Each source is guarded: outside workerd `cloudflare:workers` resolves to a
+ * stub, and reading it must never be what breaks module evaluation.
+ */
+function readWorkerEnv(name: string): unknown {
+  try {
+    return (workerEnv as unknown as Record<string, unknown> | undefined)?.[name];
+  } catch {
+    return undefined;
+  }
+}
+
+function readGlobalEnv(name: string): unknown {
+  try {
+    // worker/index.ts stashes the Worker env here for the code paths that also
+    // run in plain Node scripts and so cannot import `cloudflare:workers`.
+    const stashed = (globalThis as Record<string, unknown>).__CLOUDFLARE_ENV__;
+    return stashed ? (stashed as Record<string, unknown>)[name] : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readProcessEnv(name: string): unknown {
+  try {
+    return typeof process !== "undefined" ? process.env?.[name] : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/devdocs/AUTH_CONFIGURATION.md
+++ b/devdocs/AUTH_CONFIGURATION.md
@@ -1,0 +1,64 @@
+# Auth configuration on Cloudflare Workers
+
+`POST /api/auth/sign-in/social` returning **500** in production is almost always
+one of the two configuration problems below. Neither fails at boot, so the
+Worker deploys cleanly and only the sign-in request errors.
+
+## 1. Google credentials must reach the Worker
+
+better-auth keeps a social provider that was configured with blank credentials
+in its provider list, then throws a plain `BetterAuthError` out of
+`createAuthorizationURL`. better-call reports that as an opaque 500 with no body
+worth reading, which is exactly what the Workers log shows.
+
+`lib/auth/index.ts` now resolves its configuration through
+`serverEnv()` (`lib/env/runtime.ts`), which reads the Worker `env` first and
+falls back to `process.env`. Secrets set with `wrangler secret put` are only
+guaranteed to be on the Worker `env` — `process.env` mirrors them under
+`nodejs_compat`, but nothing in the build guarantees that mirror exists, and it
+never exists in the Node scripts that import the same modules.
+
+Google sign-in is registered only when both credentials resolve. When they do
+not, the endpoint answers with better-auth's own "Provider not found" instead of
+a 500, and the Worker logs say which variable is missing.
+
+Required secrets:
+
+```bash
+cd apps/ai-broker-web
+wrangler secret put BETTER_AUTH_SECRET
+wrangler secret put GOOGLE_CLIENT_ID
+wrangler secret put GOOGLE_CLIENT_SECRET
+wrangler secret put STRIPE_SECRET_KEY
+wrangler secret put STRIPE_WEBHOOK_SECRET
+wrangler secret list   # confirm
+```
+
+`NEXT_PUBLIC_APP_URL` is a plain `var` in `wrangler.jsonc`. It is what
+better-auth uses for `baseURL`, `trustedOrigins`, and the SIWE domain, so the
+Google OAuth redirect URI registered in Google Cloud Console must be
+`https://autoinvestment.broker/api/auth/callback/google`.
+
+## 2. Migrations must be applied to the remote D1 database
+
+`bun run deploy` ships code only. Applying migrations is a **separate** step, and
+skipping it leaves the deployed Drizzle schema describing columns the live
+database does not have. Every better-auth query naming a missing column fails,
+which surfaces as a 500 from whichever auth endpoint touched that table — the
+OAuth callback writing to `accounts` is the usual one.
+
+Always run migrations before (or immediately after) a deploy that changes
+`lib/db/schema.ts`:
+
+```bash
+cd apps/ai-broker-web
+bun run db:migrate:remote
+wrangler d1 migrations list ai-broker-db --remote   # confirm nothing is pending
+```
+
+To check the live schema directly:
+
+```bash
+wrangler d1 execute ai-broker-db --remote \
+  --command "SELECT name FROM d1_migrations ORDER BY id"
+```


### PR DESCRIPTION
## Summary

This PR refactors the quote view's external links into a reusable configuration and fixes authentication configuration to properly resolve secrets on Cloudflare Workers.

## Key Changes

### Quote View External Links Refactoring
- Extracted hardcoded broker and research links into a centralized `EXTERNAL_LINKS` configuration object
- Created reusable `ExternalLinkItem` component to render links with favicons
- Consolidated Social and Filings sections into Research group (as they were single-entry sections)
- Added favicon support using Google's public favicon service
- Improved maintainability by centralizing link management

### Auth Configuration for Cloudflare Workers
- Created `lib/env/runtime.ts` with `serverEnv()` function to properly read Worker environment variables at request time
- Updated `lib/auth/index.ts` to use `serverEnv()` for all secret resolution, with fallbacks to `process.env`
- Implemented conditional Google provider registration: only registers when both credentials are present, preventing opaque 500 errors
- Added comprehensive error logging for missing configuration
- Resolved auth configuration variables (`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`) through the Worker env first

### Documentation
- Added `devdocs/AUTH_CONFIGURATION.md` documenting:
  - Common 500 errors on `/api/auth/sign-in/social` and their causes
  - Required secrets setup with `wrangler secret put`
  - Database migration requirements for D1
  - Troubleshooting steps

## Implementation Details

The `serverEnv()` function addresses a critical issue where secrets set with `wrangler secret put` are only guaranteed on the Worker's `env` object, not in `process.env`. The function checks three sources in order:
1. Worker `env` (from `cloudflare:workers`)
2. Global stashed env (for Node scripts that can't import Worker modules)
3. `process.env` (fallback for local development)

This ensures configuration works consistently across Workers, Node scripts, and local development environments.

https://claude.ai/code/session_016gMZajaDCds9cpbuWttfx9