### PR TITLE
Add VideoLightbox component and integrate into agents section

### DIFF
--- a/apps/ai-broker-web/components/landing/agents-team-section.tsx
+++ b/apps/ai-broker-web/components/landing/agents-team-section.tsx
@@ -7,6 +7,8 @@ import {
   TrendingUp,
 } from "lucide-react"
 
+import { VideoLightbox } from "@/components/landing/video-lightbox"
+
 const agents = [
   {
     icon: BarChart3,
@@ -50,7 +52,7 @@ export function AgentsTeamSection() {
   return (
     <section id="agents" className="relative border-t border-border py-24 lg:py-32">
       <div className="mx-auto max-w-7xl px-5 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[1fr_1.4fr] lg:items-end">
+        <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr_auto] lg:items-end">
           <div>
             <div className="text-xs font-medium uppercase tracking-[0.2em] text-primary">
               The Team
@@ -65,6 +67,12 @@ export function AgentsTeamSection() {
             Every trade is the output of a specialist chain — analyst, researcher, trader, risk,
             portfolio manager. No single black box. You see who said what, and why.
           </p>
+          <VideoLightbox
+            videoId="N5cHK6K50Ds"
+            title="How the agent team builds one thesis"
+            caption="See the agents at work"
+            className="w-full max-w-xs lg:w-64"
+          />
         </div>
 
         <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/ai-broker-web/components/landing/video-lightbox.tsx
+++ b/apps/ai-broker-web/components/landing/video-lightbox.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import { Play } from "lucide-react"
+import { useState } from "react"
+
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
+
+interface VideoLightboxProps {
+  /** YouTube video id, e.g. "N5cHK6K50Ds" */
+  videoId: string
+  title: string
+  /** Short label rendered under the thumbnail */
+  caption?: string
+  className?: string
+}
+
+/**
+ * Small click-to-expand video thumbnail. Opens the full video in a large
+ * lightbox so it is actually watchable without leaving the page.
+ */
+export function VideoLightbox({
+  videoId,
+  title,
+  caption,
+  className,
+}: VideoLightboxProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={`Play video: ${title}`}
+        className={cn(
+          "group relative block w-full overflow-hidden rounded-2xl border border-border bg-card/60 text-left transition-all hover:border-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          className
+        )}
+      >
+        <span className="relative block aspect-video overflow-hidden">
+          <img
+            src={`https://img.youtube.com/vi/${videoId}/hqdefault.jpg`}
+            alt=""
+            loading="lazy"
+            className="absolute inset-0 h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+          <span className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/10 to-transparent" />
+          <span className="absolute inset-0 grid place-items-center">
+            <span className="grid h-12 w-12 place-items-center rounded-full bg-primary/90 text-primary-foreground shadow-lg transition-transform duration-300 group-hover:scale-110">
+              <Play className="ml-0.5 h-5 w-5 fill-current" />
+            </span>
+          </span>
+        </span>
+        <span className="flex items-center justify-between gap-2 px-4 py-3 text-xs">
+          <span className="font-medium text-foreground">{caption ?? title}</span>
+          <span className="text-muted-foreground">Watch</span>
+        </span>
+      </button>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent
+          className="w-[calc(100%-1.5rem)] max-w-5xl overflow-hidden border-border bg-black p-0 sm:max-w-5xl [&>button]:z-10 [&>button]:text-white"
+          aria-describedby={undefined}
+        >
+          <DialogTitle className="sr-only">{title}</DialogTitle>
+          <div className="aspect-video w-full">
+            {open ? (
+              <iframe
+                className="h-full w-full"
+                src={`https://www.youtube.com/embed/${videoId}?autoplay=1&rel=0&playsinline=1`}
+                title={title}
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+              />
+            ) : null}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
This PR introduces a new `VideoLightbox` component for displaying clickable YouTube video thumbnails that expand into a full-screen lightbox player, and integrates it into the agents team section of the landing page.

## Key Changes
- **New Component**: Created `VideoLightbox` component (`apps/ai-broker-web/components/landing/video-lightbox.tsx`)
  - Displays a YouTube video thumbnail with a play button overlay
  - Opens video in a modal dialog when clicked
  - Supports optional caption text below thumbnail
  - Includes hover animations (thumbnail zoom, play button scale)
  - Lazy loads thumbnail images for performance
  - Fully accessible with proper ARIA labels and keyboard focus states
  - Responsive design with Tailwind styling

- **Integration**: Updated `AgentsTeamSection` component
  - Imported the new `VideoLightbox` component
  - Adjusted grid layout from 2 columns to 3 columns to accommodate the video
  - Added a video lightbox showing "How the agent team builds one thesis" with YouTube ID `N5cHK6K50Ds`

## Implementation Details
- The component uses React's `useState` hook to manage the lightbox open/close state
- YouTube iframe is only rendered when the dialog is open (conditional rendering for performance)
- Autoplay is enabled when the lightbox opens
- The thumbnail image is fetched from YouTube's CDN using the video ID
- Dialog styling is customized with black background and white close button for better video viewing experience
- Supports both full screen and responsive sizing with proper aspect ratio maintenance

https://claude.ai/code/session_01VT9aZZvbdxHB98w8jzekJt