### PR TITLE
👷 ci: add Codecov coverage reporting across the monorepo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: Test and upload coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Codecov compares against the base commit, which it can only resolve
+          # with the full history.
+          fetch-depth: 0
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        # No --frozen-lockfile: lockfiles are not committed in this repo.
+        run: bun install
+
+      - name: Run tests with coverage
+        # Runs every workspace's suite, then merges the per-workspace LCOV
+        # reports into coverage/lcov.info with repo-root-relative paths.
+        run: bun run test:coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: OpenSourceAGI/ai-broker-investing-agent
+          files: ./coverage/lcov.info
+          disable_search: true
+          # Codecov being down should not block a merge; the check is
+          # informational (see codecov.yml).
+          fail_ci_if_error: false
+          verbose: true

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ docs/dist
 docs/.next
 # testing
 /coverage
+**/coverage/
+*.lcov
 *lock*
 .claude/
 # turborepo

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 <br />
     <a href="https://github.com/OpenSourceAGI/ai-broker-investing-agent/graphs/contributors" alt="Activity"><img src="https://img.shields.io/github/commit-activity/m/OpenSourceAGI/ai-broker-investing-agent" /></a>
     <a href="https://github.com/OpenSourceAGI/ai-broker-investing-agent/commits/main/"><img src="https://img.shields.io/github/last-commit/OpenSourceAGI/ai-broker-investing-agent.svg" alt="GitHub last commit" /></a>
+    <a href="https://app.codecov.io/gh/OpenSourceAGI/ai-broker-investing-agent"><img src="https://codecov.io/gh/OpenSourceAGI/ai-broker-investing-agent/branch/main/graph/badge.svg" alt="Coverage" /></a>
+    <a href="https://github.com/OpenSourceAGI/ai-broker-investing-agent/actions/workflows/test.yml"><img src="https://github.com/OpenSourceAGI/ai-broker-investing-agent/actions/workflows/test.yml/badge.svg" alt="Tests" /></a>
     <a href="https://github.com/OpenSourceAGI/ai-broker-investing-agent/discussions"><img alt="GitHub Discussions" src="https://img.shields.io/github/discussions/OpenSourceAGI/ai-broker-investing-agent" /></a>
     <a href="https://codespaces.new/OpenSourceAGI/ai-broker-investing-agent"><img src="https://github.com/codespaces/badge.svg" height="20" alt="Open in GitHub Codespaces" /></a>
 <br />
@@ -84,11 +86,26 @@ npm install                   # installs every workspace
 npm run dev                   # turbo run dev
 npm run build                 # turbo run build (packages first, then the app)
 npm run test                  # turbo run test
+npm run test:coverage         # turbo run test:coverage, then merge into coverage/lcov.info
 
 # Scope a command to a single workspace
 npx turbo run build --filter=ai-broker-web
 npx turbo run test --filter=investing
 ```
+
+### Coverage
+
+`npm run test:coverage` runs each workspace's suite with coverage on (Vitest for the app,
+`investing`, `predictos` and the API client; Jest for `fin-data-api`) and merges the
+per-workspace LCOV reports into `coverage/lcov.info` with repository-root-relative paths.
+
+CI runs the same command on every pull request in
+[`.github/workflows/test.yml`](.github/workflows/test.yml) and uploads that single report to
+[Codecov](https://app.codecov.io/gh/OpenSourceAGI/ai-broker-investing-agent). The upload needs a
+`CODECOV_TOKEN` repository or organization secret. Thresholds, the per-workspace component
+breakdown, and the paths excluded from coverage (vendored bots, generated SDKs, migrations) live
+in [`codecov.yml`](codecov.yml); the project and patch checks are informational, so a coverage dip
+never blocks a merge on its own.
 
 Each workspace documents itself:
 

--- a/apps/ai-broker-web/package.json
+++ b/apps/ai-broker-web/package.json
@@ -21,7 +21,8 @@
     "docs:generate": "fumadocs-mdx",
     "docs:generate:api": "bun lib/fumadocs/generate-api-docs.ts",
     "clean": "rm -rf dist .source .turbo .wrangler node_modules",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@alpacahq/alpaca-trade-api": "^3.1.3",
@@ -163,6 +164,7 @@
     "@types/three": "^0.182.0",
     "@vitejs/plugin-react": "^6.0.5",
     "@vitejs/plugin-rsc": "^0.5.34",
+    "@vitest/coverage-v8": "^3.2.7",
     "concurrently": "^9.2.1",
     "drizzle-kit": "^0.31.9",
     "opener": "^1.5.2",

--- a/apps/ai-broker-web/vitest.config.ts
+++ b/apps/ai-broker-web/vitest.config.ts
@@ -12,6 +12,17 @@ export default defineConfig({
     restoreMocks: true,
     unstubEnvs: true,
     unstubGlobals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+      // Only the server-side modules the vitest suite can actually reach.
+      // Pages and client components are exercised by e2e, not here, so
+      // including them would report a coverage number nothing measures.
+      include: ['lib/**/*.ts', 'app/api/**/*.ts'],
+      exclude: ['**/__tests__/**', '**/*.d.ts', '**/*.gen.ts'],
+      all: true,
+    },
   },
   resolve: {
     // An array rather than a map: vite matches aliases in order, and a bare

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,72 @@
+# Codecov configuration — https://docs.codecov.com/docs/codecovyml-reference
+codecov:
+  notify:
+    # One upload per commit, at the end of the Tests workflow — hold the status
+    # until that run finishes so Codecov never reports on a partial commit.
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...90"
+  status:
+    project:
+      default:
+        # The suite is young: hold the line against regressions rather than
+        # demanding an absolute number the repo does not meet yet.
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 70%
+        threshold: 5%
+        informational: true
+
+# Per-workspace breakdown in the Codecov UI without needing one upload per
+# package in CI.
+component_management:
+  individual_components:
+    - component_id: web
+      name: apps/ai-broker-web
+      paths:
+        - apps/ai-broker-web/**
+    - component_id: investing
+      name: packages/investing
+      paths:
+        - packages/investing/**
+    - component_id: predictos
+      name: packages/predictos
+      paths:
+        - packages/predictos/**
+    - component_id: fin_data_api
+      name: packages/fin-data-api
+      paths:
+        - packages/fin-data-api/**
+    - component_id: api_client
+      name: packages/ai-broker-api-client
+      paths:
+        - packages/ai-broker-api-client/**
+
+comment:
+  layout: "condensed_header, diff, components, condensed_files, condensed_footer"
+  behavior: default
+
+ignore:
+  # Vendored upstream bots kept for reference — not our code to test.
+  - "third-party-trading-bots/**"
+  # Generated: openapi-ts SDKs, drizzle migrations, wrangler/vinext types.
+  - "**/*.gen.ts"
+  - "**/*.d.ts"
+  - "packages/ai-broker-api-client/src/client/**"
+  - "packages/ai-broker-api-client/src/core/**"
+  - "**/drizzle/**"
+  - "**/migrations/**"
+  - "**/.source/**"
+  - "**/dist/**"
+  - "scripts/**"
+  - "devdocs/**"
+  - "**/*.test.ts"
+  - "**/*.test.js"
+  - "**/__tests__/**"
+  - "**/test/**"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "preview": "turbo run preview",
     "deploy": "turbo run deploy",
     "test": "turbo run test",
+    "test:coverage": "turbo run test:coverage && node scripts/merge-coverage.mjs",
     "lint": "turbo run lint",
     "type-check": "turbo run type-check",
     "cf-typegen": "turbo run cf-typegen",

--- a/packages/ai-broker-api-client/package.json
+++ b/packages/ai-broker-api-client/package.json
@@ -16,7 +16,8 @@
     "ship": "npx standard-version --release-as patch; npm publish",
     "build:api": "API_URL=https://autoinvestment.broker/api openapi-ts && vite build",
     "test:api": "vitest run",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "files": [
     "dist"
@@ -25,6 +26,7 @@
     "@hey-api/client-fetch": "^0.13.1",
     "@hey-api/openapi-ts": "^0.88.0",
     "@hey-api/vite-plugin": "^0.2.0",
+    "@vitest/coverage-v8": "^3.2.7",
     "terser": "^5.44.1",
     "vite": "^7.3.6",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/ai-broker-api-client/vitest.config.ts
+++ b/packages/ai-broker-api-client/vitest.config.ts
@@ -7,5 +7,15 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.{js,ts}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+      reportsDirectory: './coverage',
+      // Everything under src/ except the hand-written entry point is emitted by
+      // `openapi-ts`, so measuring it says nothing about how well this package
+      // is tested.
+      include: ['src/index.ts'],
+      all: true,
+    },
   },
 });

--- a/packages/fin-data-api/package.json
+++ b/packages/fin-data-api/package.json
@@ -10,7 +10,8 @@
     "start": "node dist/index.js",
     "test": "jest",
     "lint": "eslint src --ext .ts",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:coverage": "jest --coverage --coverageReporters=text --coverageReporters=lcov"
   },
   "keywords": [
     "finance",

--- a/packages/investing/package.json
+++ b/packages/investing/package.json
@@ -66,7 +66,8 @@
     "import:stategies": "bun lib/algo-stategies/tv-scraper.ts --pages=10",
     "import:stocks": "bun lib/stocks/import-stock-names.ts",
     "sync:high-volume-markets": "tsx scripts/sync-high-volume-markets.ts",
-    "sync:trade-history": "tsx scripts/sync-trade-history.ts"
+    "sync:trade-history": "tsx scripts/sync-trade-history.ts",
+    "test:coverage": "vitest run --coverage"
   },
   "keywords": [
     "investing",
@@ -109,6 +110,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
+    "@vitest/coverage-v8": "^3.2.7",
     "typescript": "^5.9.3",
     "vite": "^7.3.0",
     "vite-plugin-dts": "^4.5.4",

--- a/packages/investing/vitest.config.ts
+++ b/packages/investing/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
     teardownTimeout: 10000,
     isolate: true,
     pool: "forks",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/__tests__/**", "src/**/*.d.ts", "src/**/*.gen.ts"],
+      all: true,
+    },
   },
   resolve: {
     alias: {

--- a/packages/predictos/package.json
+++ b/packages/predictos/package.json
@@ -50,7 +50,8 @@
     "build": "vite build",
     "test": "vitest run",
     "test:watch": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:coverage": "vitest run --coverage"
   },
   "keywords": [
     "prediction-markets",
@@ -76,6 +77,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.0.3",
+    "@vitest/coverage-v8": "^3.2.7",
     "terser": "^5.49.2",
     "typescript": "^5.9.3",
     "vite": "^7.3.0",

--- a/packages/predictos/vitest.config.ts
+++ b/packages/predictos/vitest.config.ts
@@ -14,6 +14,14 @@ export default defineConfig({
     teardownTimeout: 10000,
     isolate: true,
     pool: "forks",
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.ts"],
+      exclude: ["src/**/__tests__/**", "src/**/*.d.ts", "src/**/*.gen.ts"],
+      all: true,
+    },
   },
   resolve: {
     alias: {

--- a/scripts/merge-coverage.mjs
+++ b/scripts/merge-coverage.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Merge every workspace's LCOV report into one repository-root report.
+ *
+ * Each workspace runs its own test runner, so `turbo run test:coverage` leaves
+ * an `lcov.info` per workspace whose `SF:` paths are relative to *that*
+ * workspace (`src/index.ts`, `lib/auth/admin.ts`, ...). Uploading those as-is
+ * is ambiguous — `src/index.ts` exists in three packages — so Codecov can
+ * attribute a file to the wrong workspace.
+ *
+ * This rewrites each `SF:` path to be relative to the repository root and
+ * concatenates the reports into `coverage/lcov.info`, which is the single file
+ * CI uploads.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+/** Workspace directories, from the root package.json `workspaces` globs. */
+function workspaceDirs() {
+  const { workspaces = [] } = JSON.parse(
+    fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"),
+  );
+
+  return workspaces.flatMap((pattern) => {
+    // Every glob in this repo is a single `<dir>/*` level.
+    const parent = pattern.replace(/\/\*$/, "");
+    const parentPath = path.join(repoRoot, parent);
+    if (!fs.existsSync(parentPath)) return [];
+
+    return fs
+      .readdirSync(parentPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.posix.join(parent, entry.name));
+  });
+}
+
+/** Rewrite `SF:` paths in an LCOV report so they resolve from the repo root. */
+function rebase(lcov, workspace) {
+  return lcov.replace(/^SF:(.*)$/gm, (_match, file) => {
+    const trimmed = file.trim();
+    const relative = path.isAbsolute(trimmed)
+      ? path.relative(repoRoot, trimmed)
+      : path.posix.join(workspace, trimmed);
+    return `SF:${relative.split(path.sep).join("/")}`;
+  });
+}
+
+const merged = [];
+const covered = [];
+
+for (const workspace of workspaceDirs()) {
+  const report = path.join(repoRoot, workspace, "coverage", "lcov.info");
+  if (!fs.existsSync(report)) continue;
+
+  const lcov = fs.readFileSync(report, "utf8");
+  if (!lcov.trim()) continue;
+
+  merged.push(rebase(lcov, workspace).trimEnd());
+  covered.push(workspace);
+}
+
+if (merged.length === 0) {
+  console.error(
+    "[coverage] No workspace produced coverage/lcov.info.\n" +
+      "  Run `bun run test:coverage` so the test runners emit their reports first.",
+  );
+  process.exit(1);
+}
+
+const outputPath = path.join(repoRoot, "coverage", "lcov.info");
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${merged.join("\n")}\n`);
+
+console.log(`[coverage] Merged ${covered.length} report(s) into coverage/lcov.info`);
+for (const workspace of covered) console.log(`  - ${workspace}`);

--- a/turbo.json
+++ b/turbo.json
@@ -65,6 +65,11 @@
         "coverage/**"
       ]
     },
+    "test:coverage": {
+      "outputs": [
+        "coverage/**"
+      ]
+    },
     "lint": {
       "dependsOn": [
         "^build"


### PR DESCRIPTION
Wire test coverage into CI and upload it to Codecov.

Every workspace now emits an LCOV report from its own runner: Vitest for apps/ai-broker-web, investing, predictos and the API client, Jest for fin-data-api. Each `SF:` path in those reports is relative to its own workspace, and `src/index.ts` exists in three packages, so uploading them as-is lets Codecov attribute a file to the wrong package. scripts/merge-coverage.mjs rebases the paths to the repository root and concatenates the reports into a single coverage/lcov.info, mirroring how `build` already post-processes turbo output with a root script.

The new Tests workflow runs `bun run test:coverage` on pull requests and pushes to main, then uploads that one file with codecov/codecov-action@v5 using the CODECOV_TOKEN secret. codecov.yml keeps the project and patch checks informational so a coverage dip cannot block a merge on its own, adds a per-workspace component breakdown, and ignores the vendored third-party bots, generated SDKs and migrations.

Coverage measures only what the suites can actually reach — the API client's generated SDK and the web app's client components are excluded rather than reported as untested.


Claude-Session: https://claude.ai/code/session_01DorHwgPg4LJiJcbij4YDxL