### PR TITLE
👷 ci: add the npm publish workflow from qwksearch-research-agent

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,457 @@
+name: Publish to npm
+
+on:
+  push:
+    branches: [main]
+  # Lets a release be kicked off by hand from the Actions tab when nothing
+  # has been pushed to main (e.g. re-running a release after fixing a token).
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish-packages:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: oven-sh/setup-bun@v2
+
+      # setup-node writes "always-auth=false" into the .npmrc it generates,
+      # but npm 10+ no longer knows that option and prints
+      # `npm warn Unknown user config "always-auth"` on every npm command.
+      # Strip the line so the logs stay clean.
+      - name: Remove deprecated always-auth npm config
+        run: |
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/^always-auth[ =]/d' "$NPM_CONFIG_USERCONFIG"
+          fi
+
+      # We don't use husky in this repo, but some dependencies ship a broken
+      # `prepare: "husky install"` in their published package.json (e.g.
+      # fuse.js). When npm reconciles bun's linked node_modules store it runs
+      # that prepare hook, which dies with "husky: not found" (exit 127) — and
+      # npm's --ignore-scripts does NOT suppress it for bun-linked packages.
+      # Put a no-op `husky` on PATH for every later step so any stray husky
+      # hook becomes a harmless no-op instead of failing the publish run.
+      - name: Neutralize unused husky hooks
+        run: |
+          mkdir -p "$RUNNER_TEMP/husky-shim"
+          printf '#!/bin/sh\nexit 0\n' > "$RUNNER_TEMP/husky-shim/husky"
+          chmod +x "$RUNNER_TEMP/husky-shim/husky"
+          echo "$RUNNER_TEMP/husky-shim" >> "$GITHUB_PATH"
+
+      # A publish credential that no longer authorizes writes is the single
+      # most likely reason for this workflow to fail, and it fails *late*: npm
+      # answers an unauthorized PUT with `E404 ... could not be found or you do
+      # not have permission to access it`, which reads like a missing package.
+      # Every package in the workspace gets built (minutes of vite) before the
+      # first one hits it, and each failed attempt still signs a provenance
+      # statement into the public sigstore transparency log. Check the
+      # credential up front instead.
+      #
+      # Two supported credentials, in order of preference:
+      #
+      #   1. Trusted publishing (OIDC). No secret at all: npm >= 11.5.1 trades
+      #      this job's `id-token` for a short-lived publish token. Nothing to
+      #      rotate and nothing to expire, but each package must name this
+      #      repo + workflow as a trusted publisher on npmjs.com
+      #      (npmjs.com/package/<name>/access -> Trusted publisher:
+      #      OpenSourceAGI/ai-broker-investing-agent, npm-publish.yml).
+      #   2. An NPM_TOKEN secret. npm granular access tokens expire (90 days
+      #      max), so this needs rotating; classic automation tokens no longer
+      #      work for direct publishing.
+      #
+      # Setting the secret picks (2); leaving it unset picks (1).
+      - name: Verify npm publish credentials
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -uo pipefail
+
+          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+            if whoami=$(npm whoami 2>&1); then
+              echo "🔑 Publishing as npm user '$whoami' (NPM_TOKEN)"
+              # The token authenticates, but that says nothing about *write*
+              # access: a read-only or differently scoped granular token gets
+              # the same E404 on PUT. Report what it can actually write to,
+              # without failing the run — `npm access` is not available to
+              # every token type, and the publish loop reports the truth.
+              if writable=$(npm access list packages --json 2>/dev/null); then
+                echo "$writable" | node -e "
+                  let s = '';
+                  process.stdin.on('data', d => s += d).on('end', () => {
+                    let perms = {};
+                    try { perms = JSON.parse(s) || {}; } catch { return; }
+                    const rw = Object.keys(perms).filter(k => perms[k] === 'read-write');
+                    console.log(rw.length
+                      ? '🔓 Token has write access to ' + rw.length + ' package(s)'
+                      : '::warning title=npm token may be read-only::The NPM_TOKEN secret authenticates but reports no packages with read-write access. Publishes will fail with E404.');
+                  });
+                "
+              fi
+              exit 0
+            fi
+            echo "$whoami"
+            echo "::error title=npm token rejected::The NPM_TOKEN secret no longer authenticates with registry.npmjs.org — it has expired, been revoked, or was replaced. npm granular access tokens expire after at most 90 days. Mint a new token with write access to these packages at npmjs.com/settings/<user>/tokens and update the NPM_TOKEN repository secret, or remove the secret entirely and configure trusted publishing (see the comment above this step)."
+            exit 1
+          fi
+
+          # No secret: trusted publishing. Make sure npm is new enough and that
+          # nothing left a half-configured empty token in the generated .npmrc,
+          # which would make npm try (and fail) to authenticate with it.
+          npm_version=$(npm --version)
+          if ! node -e "
+            const need = [11, 5, 1];
+            const have = '$npm_version'.split('.').map(Number);
+            for (let i = 0; i < 3; i++) {
+              if ((have[i] || 0) !== need[i]) process.exit((have[i] || 0) > need[i] ? 0 : 1);
+            }
+          "; then
+            echo "⏫ npm $npm_version is older than 11.5.1 — upgrading for trusted publishing (OIDC)"
+            npm install -g npm@latest
+          fi
+
+          if [ -n "${NPM_CONFIG_USERCONFIG:-}" ] && [ -f "$NPM_CONFIG_USERCONFIG" ]; then
+            sed -i '/_authToken/d' "$NPM_CONFIG_USERCONFIG"
+          fi
+          echo "🔑 No NPM_TOKEN secret — publishing via trusted publishing (OIDC) with npm $(npm --version)"
+
+      # Install the whole workspace once with bun (the repo's package manager).
+      # bun understands the "workspace:*" protocol and links local packages, so
+      # every package gets its devDependencies (e.g. vite) and can be built.
+      # Plain `npm install` cannot do this inside a bun workspace — it dies on
+      # sibling "workspace:*" deps (EUNSUPPORTEDPROTOCOL) and peer conflicts,
+      # which left devDependencies uninstalled and builds failing with
+      # "vite: not found".
+      - name: Install workspace dependencies
+        run: bun install --ignore-scripts
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish non-private packages with new content
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # GitHub runs `run:` steps with `bash -e -o pipefail`, so simply not
+          # writing `set -e` here does not disable errexit — `set -uo pipefail`
+          # leaves it on. With errexit on, the first package whose publish fails
+          # kills the whole step: once the first package in the loop started
+          # returning npm E404 on publish, every later package stopped being
+          # evaluated at all and the whole workspace went unreleased. Turn
+          # errexit off explicitly; per-package outcomes are handled through
+          # $rc below, and the run still exits non-zero at the end if anything
+          # failed.
+          set -uo pipefail
+          set +e
+
+          # The per-package subshell below `cd`s into the package directory, so
+          # capture the repo root while we are still at it.
+          repo_root="$PWD"
+
+          failed_packages=""
+          skipped_builds=""
+          unauthorized_packages=""
+          unattempted_packages=""
+          auth_broken=""
+
+          # Walk the workspace in dependency order rather than in shell-glob
+          # (alphabetical) order. bun links workspace packages into node_modules
+          # as symlinks, so a sibling that has not been built yet has no dist/
+          # and the `exports` -> `types` entries in its package.json point at
+          # files that do not exist. Alphabetically, `research-agent-ui` ran its
+          # declaration build before shadcn-app-dock, trending-news-api and
+          # use-voice-control were built, and tsc reported every import of them
+          # as "Cannot find module ... or its corresponding type declarations".
+          # Dependency order also means a sibling's `workspace:*` pin below is
+          # rewritten to the version that sibling just published, not the one it
+          # had before its bump.
+          build_order=$(node scripts/workspace-build-order.mjs)
+          echo "📋 Build order:"
+          echo "$build_order" | sed 's/^/   /'
+
+          for dir in $build_order; do
+            pkg="${dir}package.json"
+
+            if [ ! -f "$pkg" ]; then
+              echo "⏭ Skipping $dir (no package.json)"
+              continue
+            fi
+
+            is_private=$(node -e "const p=require('./$pkg'); console.log(!!p.private)")
+            name=$(node -e "const p=require('./$pkg'); console.log(p.name)")
+
+            if [ "$is_private" = "true" ]; then
+              echo "⏭ Skipping $name (private)"
+              continue
+            fi
+
+            # One rejected PUT means the credential cannot write, and every
+            # remaining package would fail the same way — after another vite
+            # build each, and after signing a provenance statement into the
+            # public sigstore transparency log for a version that will never
+            # exist. Stop attempting them; the run still fails at the end.
+            if [ -n "$auth_broken" ]; then
+              echo "⏭ Skipping $name (npm rejected the publish credential — see above)"
+              unattempted_packages="$unattempted_packages $name"
+              continue
+            fi
+
+            echo "📦 Evaluating $name from $dir"
+
+            # Each package is handled in a subshell with its own `set -e` so a
+            # failing step propagates to $rc without killing the outer loop.
+            (
+              set -e
+              cd "$dir"
+
+              # npm keeps a local dependency protocol -- bun's "workspace:*" and
+              # npm's "file:../sibling" alike -- literally in the tarball, where
+              # consumers cannot resolve it. Replace each with a real semver
+              # range ("^<version>") taken from the referenced local package so
+              # published packages keep depending on their siblings. A local
+              # package that isn't published is dropped instead.
+              # (This edit is only committed back if the version gets bumped.)
+              node -e "
+                const fs = require('fs');
+                const path = require('path');
+                // Map local package name -> version across the workspace.
+                const localVersions = {};
+                for (const d of fs.readdirSync('..')) {
+                  const sib = path.join('..', d, 'package.json');
+                  if (!fs.existsSync(sib)) continue;
+                  try {
+                    const sp = JSON.parse(fs.readFileSync(sib, 'utf8'));
+                    if (sp.name && sp.version) localVersions[sp.name] = sp.version;
+                  } catch {}
+                }
+                const p = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+                for (const s of ['dependencies', 'devDependencies', 'peerDependencies']) {
+                  if (!p[s]) continue;
+                  for (const [k, v] of Object.entries(p[s])) {
+                    if (typeof v !== 'string') continue;
+                    if (!v.startsWith('workspace:') && !v.startsWith('file:')) continue;
+                    if (localVersions[k]) {
+                      p[s][k] = '^' + localVersions[k];
+                      console.log('Pinned local dependency', k, '->', p[s][k]);
+                    } else {
+                      delete p[s][k];
+                      console.log('Removed unresolved local dependency:', k);
+                    }
+                  }
+                }
+                fs.writeFileSync('package.json', JSON.stringify(p, null, 2));
+              "
+
+              # Build before deciding anything: the tarball content comparison
+              # below needs the real dist output, and we never publish a
+              # package whose build fails.
+              has_build=$(node -e "const p=require('./package.json'); console.log(!!(p.scripts && p.scripts.build))")
+              if [ "$has_build" = "true" ]; then
+                if ! npm run build; then
+                  echo "⚠ Build failed for $name — not publishing (won't ship a broken tarball)"
+                  exit 42
+                fi
+              fi
+
+              version=$(node -e "const p=require('./package.json'); console.log(p.version)")
+              latest=$(npm view "$name" version 2>/dev/null || echo "")
+              already=$(npm view "$name@$version" version 2>/dev/null || echo "")
+
+              # If the local version has fallen behind the registry's latest
+              # (e.g. a bump commit never landed back in the repo), publishing
+              # would fail with "Cannot implicitly apply the latest tag".
+              # Sync to the registry's latest first, then let the content
+              # comparison below decide whether anything new needs releasing.
+              if [ -z "$already" ] && [ -n "$latest" ]; then
+                behind=$(node -e "
+                  const cmp = (x, y) => { const a = x.split('.').map(Number), b = y.split('.').map(Number); for (let i = 0; i < 3; i++) { if ((a[i]||0) !== (b[i]||0)) return (a[i]||0) - (b[i]||0); } return 0; };
+                  console.log(cmp('$version', '$latest') < 0);
+                ")
+                if [ "$behind" = "true" ]; then
+                  echo "⏫ $name local version $version is behind npm latest $latest — syncing"
+                  npm version "$latest" --no-git-tag-version --no-workspaces
+                  version="$latest"
+                  already="$latest"
+                fi
+              fi
+
+              if [ -n "$already" ]; then
+                # This exact version is on npm. Publish anyway if the content
+                # changed since that release: npm tarballs are reproducible
+                # (normalized mtimes), so compare pack integrity against the
+                # registry. Identical content ⇒ nothing new to release.
+                local_integrity=$(npm pack --dry-run --ignore-scripts --json 2>/dev/null | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s)[0].integrity))")
+                remote_integrity=$(npm view "$name@$version" dist.integrity 2>/dev/null || echo "")
+
+                if [ "$local_integrity" = "$remote_integrity" ]; then
+                  echo "⏭ $name@$version already on npm with identical content — nothing new to release"
+                  exit 0
+                fi
+
+                # Content changed since the last release: take the next
+                # version the registry has not already spent. Bumping one patch
+                # above `latest` is not enough — the `latest` dist-tag lags any
+                # version that was staged by an interrupted publish, and npm
+                # answers a PUT for one of those with
+                # `E409 ... Cannot publish over previously staged version`.
+                # next-free-version.mjs reads the full version list *and* the
+                # release timeline, which is where those numbers show up.
+                next=$(node "$repo_root/scripts/next-free-version.mjs" "$name" "$version")
+                echo "🔼 $name content changed since $version — bumping to $next"
+                # --no-workspaces prevents npm from doing workspace-aware processing
+                # when bun's workspace symlinks are present in node_modules (e.g.
+                # write-language -> ../../write-language), which would otherwise
+                # trigger EUNSUPPORTEDPROTOCOL workspace:* errors.
+                npm version "$next" --no-git-tag-version --no-workspaces
+                version="$next"
+              fi
+
+              # Already built above; skip prepare/prepublish hooks re-running it.
+              # Exit 43 for an authorization failure so the loop can stop early:
+              # npm reports "no write access" as E404 on the PUT, which reads as
+              # if the package did not exist.
+              #
+              # A version the registry has reserved but does not list is still
+              # possible (the reservation can land between the version query
+              # above and the PUT), so an E409 "cannot publish over" is retried
+              # at the next free version rather than failing the package. The
+              # attempt cap keeps a registry that rejects everything from
+              # looping: five refusals is a problem no amount of bumping fixes.
+              log="$RUNNER_TEMP/npm-publish.log"
+              attempt=1
+
+              while :; do
+                echo "Publishing $name@$version"
+                if npm publish --provenance --access public --ignore-scripts 2>&1 | tee "$log"; then
+                  exit 0
+                fi
+
+                if grep -qE "npm error code (E401|E404|ENEEDAUTH|EAUTHUNKNOWN|EOTP)" "$log"; then
+                  exit 43
+                fi
+                if grep -q "npm error code E403" "$log" && ! grep -qi "cannot publish over" "$log"; then
+                  exit 43
+                fi
+
+                if ! grep -qi "cannot publish over" "$log"; then
+                  exit 1
+                fi
+                if [ "$attempt" -ge 5 ]; then
+                  echo "⚠ npm refused $attempt versions in a row for $name — giving up"
+                  exit 1
+                fi
+
+                next=$(node "$repo_root/scripts/next-free-version.mjs" "$name" "$version")
+                echo "↩ npm has $name@$version reserved — retrying as $next"
+                npm version "$next" --no-git-tag-version --no-workspaces
+                version="$next"
+                attempt=$((attempt + 1))
+              done
+            )
+            rc=$?
+
+            if [ "$rc" = "42" ]; then
+              skipped_builds="$skipped_builds $name"
+            elif [ "$rc" = "43" ]; then
+              unauthorized_packages="$unauthorized_packages $name"
+              auth_broken="1"
+            elif [ "$rc" != "0" ]; then
+              failed_packages="$failed_packages $name"
+            fi
+          done
+
+          if [ -n "$skipped_builds" ]; then
+            echo "::warning::Skipped (build failed, not published):$skipped_builds"
+          fi
+
+          if [ -n "$unattempted_packages" ]; then
+            echo "⏭ Not attempted (the credential was already rejected):$unattempted_packages"
+          fi
+
+          if [ -n "$unauthorized_packages" ]; then
+            echo "❌ Not authorized to publish:$unauthorized_packages"
+            echo "::error title=npm rejected the publish credential::npm answers an unauthorized PUT with E404 ('could not be found or you do not have permission to access it'), so this reads as a missing package — the packages exist, the write was refused. The NPM_TOKEN secret is read-only, scoped to a different set of packages, or expired (granular tokens last 90 days at most); or, if trusted publishing is in use, this repo + workflow is not yet named as the trusted publisher for these packages on npmjs.com."
+          fi
+
+          if [ -n "$failed_packages" ]; then
+            echo "❌ Failed to publish:$failed_packages"
+          fi
+
+          if [ -n "$failed_packages" ] || [ -n "$unauthorized_packages" ] || [ -n "$unattempted_packages" ]; then
+            exit 1
+          fi
+
+      - name: Commit version bumps
+        if: success()
+        run: |
+          # Version bumps made during publish (content changed while the version
+          # was already taken) must land back in the repo so the next run sees
+          # them. Restore the workspace:* pinning done for the tarballs first —
+          # only the "version" field should be committed.
+          node -e "
+            const fs = require('fs');
+            const cp = require('child_process');
+            for (const d of fs.readdirSync('packages')) {
+              const f = 'packages/' + d + '/package.json';
+              if (!fs.existsSync(f)) continue;
+              const now = JSON.parse(fs.readFileSync(f, 'utf8'));
+              let raw;
+              try {
+                raw = cp.execSync('git show HEAD:' + f, { encoding: 'utf8' });
+              } catch { continue; }
+              const orig = JSON.parse(raw);
+              if (orig.version !== now.version) {
+                // Patch only the version string so the file keeps its formatting.
+                raw = raw.replace(
+                  '\"version\": \"' + orig.version + '\"',
+                  '\"version\": \"' + now.version + '\"'
+                );
+                console.log('Keeping version bump for', now.name, '->', now.version);
+              }
+              fs.writeFileSync(f, raw);
+            }
+          "
+          git add packages/*/package.json
+          git diff --staged --quiet && echo "No version changes to commit" && exit 0
+
+          # Refresh the lockfile in the same commit as the package.json edits.
+          # A bare version bump does not move it (bun neither rewrites nor
+          # checks a workspace package's own "version" field), but a bump that
+          # rides along with a dependency edit does, and a bun.lock left behind
+          # by one commit kills every deploy after it.
+          #
+          # This repo's .gitignore excludes lockfiles, so there is usually
+          # nothing to refresh -- only touch bun.lock when it is actually
+          # tracked, or `git add` fails the step on an ignored path.
+          if git ls-files --error-unmatch bun.lock >/dev/null 2>&1; then
+            bun install --lockfile-only
+            git add bun.lock
+
+            # [skip ci] keeps every other workflow off this commit, so a
+            # deploy build is the first thing that ever runs an install on
+            # it -- which is how a stale lockfile reaches production as
+            #   error: lockfile had changes, but lockfile is frozen
+            # instead of as a failed check. Prove the commit installs before
+            # it is pushed.
+            if ! bun install --frozen-lockfile; then
+              echo "::error title=Version bump would leave bun.lock stale::'bun install --lockfile-only' did not converge the lockfile for this bump, so the commit was not pushed. Regenerate bun.lock by hand and commit it before publishing again."
+              exit 1
+            fi
+          fi
+
+          git commit -m "chore: bump published package versions [skip ci]"
+          git push

--- a/packages/ai-broker-api-client/package.json
+++ b/packages/ai-broker-api-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ai-broker-api-client",
   "version": "0.0.11",
+  "private": true,
   "description": "AI Broker API Client",
   "type": "module",
   "main": "./dist/api-client.js",

--- a/packages/fin-data-api/package.json
+++ b/packages/fin-data-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fin-data-api",
   "version": "1.0.0",
+  "private": true,
   "description": "TypeScript Financial Data API with OpenAPI/Scalar documentation - converted from OpenBB Finance APIs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/investing/package.json
+++ b/packages/investing/package.json
@@ -4,6 +4,11 @@
   "description": "Reusable investment utilities, trading agents, and financial data tools",
   "license": "rights.institute/prosper",
   "author": "vtempest",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/ai-broker-investing-agent.git",
+    "directory": "packages/investing"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "api-mcp-server",
   "version": "1.0.0",
+  "private": true,
   "description": "MCP server generated from OpenAPI spec (33 tools)",
   "type": "module",
   "main": "src/index.js",

--- a/packages/predictos/package.json
+++ b/packages/predictos/package.json
@@ -4,6 +4,11 @@
   "description": "PredictOS 'Super Intelligence' core (prediction-market multi-agent analysis, data clients, and cross-platform arbitrage) adapted from PredictionXBT/PredictOS, refactored from Deno/Supabase edge functions into Node/TypeScript ESM.",
   "license": "MIT",
   "author": "PredictionXBT (original); adapted for the investing package",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/OpenSourceAGI/ai-broker-investing-agent.git",
+    "directory": "packages/predictos"
+  },
   "type": "module",
   "exports": {
     ".": {

--- a/scripts/next-free-version.mjs
+++ b/scripts/next-free-version.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Pick the next version npm will actually accept for a package.
+ *
+ * The publish workflow used to bump one patch above whichever was higher, the
+ * local version or the registry's `latest` dist-tag, and assume the result was
+ * free. It is not: the registry refuses a PUT for any version it has *ever*
+ * seen, and plenty of those are invisible to `latest`.
+ *
+ *   npm error code E409
+ *   npm error 409 Conflict - PUT https://registry.npmjs.org/extract-pdf
+ *     - Cannot publish over previously staged version "0.1.275".
+ *
+ * A version reaches that state when a publish is interrupted part-way, when it
+ * was published and later unpublished, or when it only ever carried a dist-tag
+ * other than `latest`. A whole workspace can hit this in a single run, each
+ * package having "bumped" straight onto a number the registry had already
+ * reserved.
+ *
+ * So treat the registry as the source of truth for which numbers are spent.
+ * `versions` lists what is currently published; `time` additionally keeps an
+ * entry for every version that ever existed, including staged and unpublished
+ * ones — the exact numbers `latest` cannot see. The union of the two is the
+ * taken set.
+ *
+ * Usage: node scripts/next-free-version.mjs <package-name> <local-version>
+ *   Prints the next free version, always strictly above <local-version>. If
+ *   the registry says nothing about the package (a first publish, or an
+ *   unreachable registry) that is just <local-version> plus a patch.
+ */
+import { execFileSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
+
+/** A plain `major.minor.patch` release — what every package here publishes. */
+const RELEASE = /^(\d+)\.(\d+)\.(\d+)$/;
+
+/**
+ * Compare two `major.minor.patch` versions numerically.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number} negative if a < b, 0 if equal, positive if a > b
+ */
+export function compareVersions(a, b) {
+  const left = a.split('.').map(Number);
+  const right = b.split('.').map(Number);
+
+  for (let i = 0; i < 3; i++) {
+    const diff = (left[i] || 0) - (right[i] || 0);
+    if (diff !== 0) return diff;
+  }
+
+  return 0;
+}
+
+/**
+ * @param {string} version
+ * @returns {string} the same version with its patch incremented
+ */
+export function bumpPatch(version) {
+  const parts = version.split('.').map(Number);
+  parts[2] = (parts[2] || 0) + 1;
+  return parts.slice(0, 3).join('.');
+}
+
+/**
+ * Every version number the registry has ever handed out for a package.
+ *
+ * `time` is the important half: npm keeps a timestamp for versions that are no
+ * longer listed in `versions` (unpublished, or staged by a publish that never
+ * finished), and those are exactly the ones that answer a fresh PUT with E409.
+ *
+ * @param {{ versions?: string[] | string, time?: Record<string, string> }} packument
+ * @returns {Set<string>}
+ */
+export function takenVersions(packument) {
+  const taken = new Set();
+  if (!packument) return taken;
+
+  // `npm view <name> versions --json` collapses a single-version package to a
+  // bare string rather than a one-element array.
+  const versions = packument.versions;
+  for (const version of Array.isArray(versions)
+    ? versions
+    : versions
+      ? [versions]
+      : []) {
+    if (RELEASE.test(version)) taken.add(version);
+  }
+
+  // `time` also carries `created`, `modified` and (for a wholly unpublished
+  // package) `unpublished`; only the version-shaped keys matter here.
+  for (const key of Object.keys(packument.time || {})) {
+    if (RELEASE.test(key)) taken.add(key);
+  }
+
+  return taken;
+}
+
+/**
+ * The lowest free version that is strictly above both `local` and everything
+ * the registry has ever spent.
+ *
+ * Always a bump, never `local` itself: both callers already know `local`
+ * cannot be published — the workflow reaches here either because that version
+ * is on npm with different content, or because a publish attempt just came
+ * back E409 for a version the registry will not admit to knowing.
+ *
+ * @param {string} local version in the package's own package.json
+ * @param {Set<string>} taken every version the registry has ever seen
+ * @returns {string}
+ */
+export function nextFreeVersion(local, taken) {
+  let highest = RELEASE.test(local) ? local : '0.0.0';
+  for (const version of taken) {
+    if (compareVersions(version, highest) > 0) highest = version;
+  }
+
+  let next = bumpPatch(highest);
+  // A gap in the taken set can only be below `highest`, so this loop normally
+  // runs zero times; it is here so a registry that reports versions out of
+  // order still cannot produce a number that is already spent.
+  while (taken.has(next)) next = bumpPatch(next);
+
+  return next;
+}
+
+/**
+ * Ask npm for a package's published versions and its full release timeline.
+ *
+ * A package that has never been published (E404) and an unreachable registry
+ * look the same from here: both yield an empty packument, so the answer comes
+ * from the local version alone.
+ *
+ * @param {string} name
+ * @param {(cmd: string, args: string[]) => string} [run] injection point for tests
+ * @returns {{ versions?: string[], time?: Record<string, string> }}
+ */
+export function fetchPackument(name, run = defaultRun) {
+  let raw;
+  try {
+    raw = run('npm', ['view', name, 'versions', 'time', '--json']);
+  } catch {
+    return {};
+  }
+
+  if (!raw || !raw.trim()) return {};
+
+  try {
+    return JSON.parse(raw) || {};
+  } catch {
+    return {};
+  }
+}
+
+function defaultRun(cmd, args) {
+  return execFileSync(cmd, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+  const [name, local] = process.argv.slice(2);
+
+  if (!name || !local) {
+    console.error('Usage: node scripts/next-free-version.mjs <package-name> <local-version>');
+    process.exit(2);
+  }
+
+  console.log(nextFreeVersion(local, takenVersions(fetchPackument(name))));
+}

--- a/scripts/workspace-build-order.mjs
+++ b/scripts/workspace-build-order.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Order the workspace's package directories so that every package comes after
+ * each sibling it depends on.
+ *
+ * The npm publish workflow used to walk `packages/*​/`, i.e. shell-glob
+ * (alphabetical) order, which has nothing to do with the dependency graph.
+ * `bun install` links workspace packages into `node_modules` as symlinks, so a
+ * sibling that has not been built yet has no `dist/` and the `exports` ->
+ * `types` entries in its package.json point at files that do not exist. A
+ * package that sorts before its own dependency then fails its declaration
+ * build on it:
+ *
+ *   Cannot find module 'predictos' or its corresponding type declarations.
+ *
+ * Usage: node scripts/workspace-build-order.mjs [rootDir]
+ *   rootDir defaults to `packages`. Prints one directory per line, with a
+ *   trailing slash, e.g. `packages/investing/`.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+/**
+ * Read every `<root>/<dir>/package.json` that exists.
+ *
+ * @param {string} root
+ * @returns {{ dir: string, pkg: Record<string, any> }[]}
+ */
+export function readWorkspacePackages(root) {
+  const packages = [];
+
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+
+    const manifest = path.join(root, entry.name, 'package.json');
+    if (!fs.existsSync(manifest)) continue;
+
+    let pkg;
+    try {
+      pkg = JSON.parse(fs.readFileSync(manifest, 'utf8'));
+    } catch (error) {
+      console.error(`Skipping ${manifest}: ${error.message}`);
+      continue;
+    }
+    if (!pkg.name) continue;
+
+    packages.push({ dir: entry.name, pkg });
+  }
+
+  return packages;
+}
+
+/**
+ * Map each package directory to the sibling directories it depends on.
+ *
+ * Local edges are keyed by package *name*, not by the version range: bun links
+ * a sibling into node_modules whenever the name matches a workspace package, so
+ * `"use-voice-control": "^0.1.37"` resolves to the local copy exactly like
+ * `"workspace:*"` does, and needs building just the same.
+ *
+ * @param {{ dir: string, pkg: Record<string, any> }[]} packages
+ * @returns {Map<string, Set<string>>}
+ */
+export function localDependencyGraph(packages) {
+  const dirByName = new Map(packages.map(({ dir, pkg }) => [pkg.name, dir]));
+  const graph = new Map();
+
+  for (const { dir, pkg } of packages) {
+    const local = new Set();
+    for (const field of [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+    ]) {
+      for (const name of Object.keys(pkg[field] ?? {})) {
+        const depDir = dirByName.get(name);
+        if (depDir && depDir !== dir) local.add(depDir);
+      }
+    }
+    graph.set(dir, local);
+  }
+
+  return graph;
+}
+
+/**
+ * Topologically sort the workspace, alphabetically within each ready set so the
+ * order is stable across runs and stays close to the old one where the graph
+ * allows it.
+ *
+ * @param {string} [root]
+ * @returns {string[]} directories, e.g. `['packages/domain-rank/', ...]`
+ */
+export function workspaceBuildOrder(root = 'packages') {
+  const packages = readWorkspacePackages(root);
+  const dependencies = localDependencyGraph(packages);
+
+  const pending = packages.map(({ dir }) => dir).sort();
+  const built = new Set();
+  const order = [];
+
+  while (pending.length > 0) {
+    const ready = pending.findIndex((dir) =>
+      [...dependencies.get(dir)].every((dep) => built.has(dep)),
+    );
+
+    // A dependency cycle leaves nothing ready. No order can be right, so take
+    // the alphabetically first entry and keep going: everything still gets
+    // built and published, and the cycle is reported on stderr where it shows
+    // up in the job log.
+    if (ready === -1) {
+      console.error(
+        `Dependency cycle involving ${pending[0]} — falling back to alphabetical order for it`,
+      );
+    }
+
+    const [dir] = pending.splice(ready === -1 ? 0 : ready, 1);
+    built.add(dir);
+    order.push(`${root}/${dir}/`);
+  }
+
+  return order;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  console.log(workspaceBuildOrder(process.argv[2]).join('\n'));
+}


### PR DESCRIPTION
Ports `.github/workflows/npm-publish.yml` and its two helper scripts (`workspace-build-order.mjs`, `next-free-version.mjs`) from OpenSourceAGI/qwksearch-research-agent, so a push to `main` releases every non-private workspace package whose tarball content has changed since its last release. Also runnable by hand from the Actions tab.

Adapted for this repo:

- Triggers on `main` instead of `master`, and names this repo as the trusted publisher in the credential comment.
- The workspace-pin step now rewrites `file:../sibling` ranges as well as bun's `workspace:*` — `investing` depends on `predictos` through `file:`, which npm would otherwise leave literally in the tarball where no consumer can resolve it.
- The version-bump commit only refreshes a lockfile when one is tracked; this repo's .gitignore excludes lockfiles, and `git add bun.lock` on an ignored path would fail the step.

Package metadata the workflow needs:

- `investing` and `predictos` get a `repository` field. `npm publish --provenance` refuses to sign a tarball without one.
- `api-mcp-server`, `fin-data-api` and `ai-broker-api-client` are marked private so the release loop skips them. `api-mcp-server` is an unrelated third party's name on npm, and an unauthorized PUT would come back as E404 and abort the rest of the run; `ai-broker-api-client` has no `build` script, so its `files: ["dist"]` allowlist would ship an empty tarball (dist is gitignored); `fin-data-api` is a server app with no files allowlist. Dropping `"private": true` from any of them is the one-line opt-in once it is meant to be released.


Claude-Session: https://claude.ai/code/session_017nUNDfMKLY6VNtpkV33Vuc