### PR TITLE
Fix stock API validation, caching, and chart zoom resolution

### DIFF
--- a/apps/ai-broker-web/app/api/stocks/__tests__/historical-route.test.ts
+++ b/apps/ai-broker-web/app/api/stocks/__tests__/historical-route.test.ts
@@ -1,0 +1,300 @@
+/**
+ * @fileoverview Route tests for GET /api/stocks/historical/[symbol].
+ *
+ * Covers the three things that were wrong in production: partial tickers from a
+ * search box reaching the data providers before being refused, the cache branch
+ * that could never be taken because it compared trading days against calendar
+ * days, and the period bounds reported from an unsorted row set.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// `vi.mock` factories are hoisted above module-level consts, so the spy the
+// fake wrapper closes over has to be hoisted with them.
+const { getHistoricalData } = vi.hoisted(() => ({ getHistoricalData: vi.fn() }))
+
+vi.mock('@/packages/investing/src/stocks/finnhub-wrapper', () => ({
+  FinnhubWrapper: class {
+    getHistoricalData = getHistoricalData
+  },
+}))
+vi.mock('@/packages/investing/src/stocks/quote-cache-service', () => ({
+  quoteCacheService: {
+    getCachedHistoricalQuotes: vi.fn(),
+    saveHistoricalQuotes: vi.fn(),
+  },
+}))
+
+import { quoteCacheService } from '@/packages/investing/src/stocks/quote-cache-service'
+import { routeContext } from '../../__tests__/helpers/fake-db'
+import { GET } from '../historical/[symbol]/route'
+
+const mockGetCached = quoteCacheService.getCachedHistoricalQuotes as unknown as ReturnType<typeof vi.fn>
+const mockSaveCached = quoteCacheService.saveHistoricalQuotes as unknown as ReturnType<typeof vi.fn>
+
+/** `count` consecutive daily bars ending today, oldest first. */
+function bars(count: number, startPrice = 100) {
+  return Array.from({ length: count }, (_, i) => {
+    const date = new Date()
+    date.setDate(date.getDate() - (count - 1 - i))
+    return {
+      date: date.toISOString().split('T')[0],
+      open: startPrice + i,
+      high: startPrice + i + 1,
+      low: startPrice + i - 1,
+      close: startPrice + i + 0.5,
+      volume: 1_000_000 + i,
+    }
+  })
+}
+
+const call = (symbol: string, search = '') =>
+  GET(
+    new NextRequest(
+      `http://localhost/api/stocks/historical/${encodeURIComponent(symbol)}${search}`,
+    ),
+    routeContext({ symbol }),
+  )
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetCached.mockResolvedValue([])
+  mockSaveCached.mockResolvedValue(undefined)
+})
+
+describe('GET /api/stocks/historical/[symbol] — validation', () => {
+  it.each(['GOO', 'GOOH', 'GOOHL', 'GOOGLE'])(
+    'refuses the partial ticker %s without calling a provider',
+    async (partial) => {
+      const res = await call(partial, '?range=5y&interval=1d')
+
+      expect(res.status).toBeGreaterThanOrEqual(400)
+      expect(res.status).toBeLessThan(500)
+      expect(getHistoricalData).not.toHaveBeenCalled()
+      expect(mockGetCached).not.toHaveBeenCalled()
+    },
+  )
+
+  it('distinguishes a malformed ticker (400) from an unlisted one (404)', async () => {
+    expect((await call('GOOGLE')).status).toBe(400)
+    expect((await call('ZZZZZ')).status).toBe(404)
+  })
+
+  it('upper-cases the symbol before fetching', async () => {
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: bars(5), meta: {} },
+    })
+
+    await call('aapl', '?range=1mo&interval=1d&cache=false')
+
+    expect(getHistoricalData).toHaveBeenCalledWith(
+      expect.objectContaining({ symbol: 'AAPL' }),
+    )
+  })
+})
+
+describe('GET /api/stocks/historical/[symbol] — range handling', () => {
+  beforeEach(() => {
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: bars(10), meta: { currency: 'USD', symbol: 'AAPL' } },
+    })
+  })
+
+  it.each([
+    ['1d', 1],
+    ['5d', 5],
+    ['1mo', 31],
+    ['1y', 366],
+    ['2y', 731],
+    ['5y', 1827],
+  ])('turns range=%s into a start date about %i days back', async (range, days) => {
+    await call('AAPL', `?range=${range}&interval=1d&cache=false`)
+
+    const { period1, period2 } = getHistoricalData.mock.calls[0][0]
+    const spanDays = (new Date(period2).getTime() - new Date(period1).getTime()) / 86_400_000
+    expect(spanDays).toBeGreaterThan(days - 3)
+    expect(spanDays).toBeLessThan(days + 3)
+  })
+
+  it('prefers explicit period1/period2 over range', async () => {
+    await call('AAPL', '?period1=1704067200&period2=1735689600&interval=1d&cache=false')
+
+    expect(getHistoricalData).toHaveBeenCalledWith(
+      expect.objectContaining({ period1: '1704067200', period2: '1735689600' }),
+    )
+  })
+
+  it('falls back to one month for an unrecognized range', async () => {
+    await call('AAPL', '?range=banana&interval=1d&cache=false')
+
+    const { period1, period2 } = getHistoricalData.mock.calls[0][0]
+    const spanDays = (new Date(period2).getTime() - new Date(period1).getTime()) / 86_400_000
+    expect(spanDays).toBeGreaterThan(27)
+    expect(spanDays).toBeLessThan(32)
+  })
+})
+
+describe('GET /api/stocks/historical/[symbol] — cache', () => {
+  it('serves a year of cached bars without calling a provider', async () => {
+    // ~252 trading days is a complete year, but only ~69% of its calendar days.
+    // Measured against calendar days this branch could never be taken.
+    mockGetCached.mockResolvedValue(bars(252))
+
+    const res = await call('AAPL', '?range=1y&interval=1d')
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.source).toBe('cache')
+    expect(body.dataPoints).toBe(252)
+    expect(getHistoricalData).not.toHaveBeenCalled()
+  })
+
+  it('reports the period from the first and last cached bar', async () => {
+    const cached = bars(252)
+    mockGetCached.mockResolvedValue(cached)
+
+    const body = await (await call('AAPL', '?range=1y&interval=1d')).json()
+
+    expect(body.period.start).toBe(cached[0].date)
+    expect(body.period.end).toBe(cached[cached.length - 1].date)
+  })
+
+  it('refetches when the cache holds only a sliver of the window', async () => {
+    mockGetCached.mockResolvedValue(bars(5))
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: bars(250), meta: {} },
+    })
+
+    const body = await (await call('AAPL', '?range=1y&interval=1d')).json()
+
+    expect(getHistoricalData).toHaveBeenCalled()
+    expect(body.source).toBe('finnhub')
+  })
+
+  it('skips the cache entirely when cache=false', async () => {
+    mockGetCached.mockResolvedValue(bars(252))
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: bars(250), meta: {} },
+    })
+
+    await call('AAPL', '?range=1y&interval=1d&cache=false')
+
+    expect(mockGetCached).not.toHaveBeenCalled()
+    expect(getHistoricalData).toHaveBeenCalled()
+  })
+
+  it('does not read the cache for intraday intervals', async () => {
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: bars(30), meta: {} },
+    })
+
+    await call('AAPL', '?range=5d&interval=5m')
+
+    expect(mockGetCached).not.toHaveBeenCalled()
+  })
+
+  it('writes freshly fetched daily bars back to the cache', async () => {
+    const fetched = bars(250)
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: fetched, meta: {} },
+    })
+
+    await call('AAPL', '?range=1y&interval=1d')
+
+    expect(mockSaveCached).toHaveBeenCalledWith('AAPL', fetched)
+  })
+
+  it('still answers when writing to the cache fails', async () => {
+    mockSaveCached.mockRejectedValue(new Error('D1 unavailable'))
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: bars(250), meta: {} },
+    })
+
+    expect((await call('AAPL', '?range=1y&interval=1d')).status).toBe(200)
+  })
+})
+
+describe('GET /api/stocks/historical/[symbol] — no data', () => {
+  it('answers 404 NO_DATA when every provider comes back empty', async () => {
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: { quotes: [] },
+    })
+
+    const res = await call('AAPL', '?range=1y&interval=1d')
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toMatchObject({ success: false, code: 'NO_DATA' })
+  })
+
+  it('hints at the missing credentials when no provider key is configured', async () => {
+    vi.stubEnv('FINNHUB_API_KEY', '')
+    vi.stubEnv('ALPACA_API_KEY', '')
+    vi.stubEnv('APCA_API_KEY_ID', '')
+    getHistoricalData.mockResolvedValue({ success: false, error: 'no keys' })
+
+    const body = await (await call('AAPL', '?range=1y&interval=1d')).json()
+
+    expect(body.hint).toMatch(/No API keys configured/)
+  })
+
+  it('hints at a shorter range for a long window that came back empty', async () => {
+    vi.stubEnv('FINNHUB_API_KEY', 'test-key')
+    getHistoricalData.mockResolvedValue({ success: true, data: { quotes: [] } })
+
+    const body = await (await call('AAPL', '?range=5y&interval=1d')).json()
+
+    expect(body.hint).toMatch(/Try a shorter range/)
+  })
+
+  it('answers 500 when the provider throws unexpectedly', async () => {
+    getHistoricalData.mockRejectedValue(new Error('socket hang up'))
+
+    const res = await call('AAPL', '?range=1y&interval=1d')
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({ code: 'HISTORICAL_ERROR' })
+  })
+})
+
+describe('GET /api/stocks/historical/[symbol] — success payload', () => {
+  it('returns the bars with their period, source and metadata', async () => {
+    const quotes = bars(250)
+    getHistoricalData.mockResolvedValue({
+      success: true,
+      source: 'finnhub',
+      data: {
+        quotes,
+        meta: { currency: 'USD', symbol: 'AAPL', exchangeName: 'NASDAQ' },
+      },
+    })
+
+    const body = await (await call('AAPL', '?range=1y&interval=1d')).json()
+
+    expect(body).toMatchObject({
+      success: true,
+      symbol: 'AAPL',
+      source: 'finnhub',
+      interval: '1d',
+      dataPoints: quotes.length,
+      meta: { currency: 'USD', symbol: 'AAPL', exchangeName: 'NASDAQ' },
+    })
+    expect(body.period.start).toBe(quotes[0].date)
+    expect(body.period.end).toBe(quotes[quotes.length - 1].date)
+  })
+})

--- a/apps/ai-broker-web/app/api/stocks/__tests__/quote-route.test.ts
+++ b/apps/ai-broker-web/app/api/stocks/__tests__/quote-route.test.ts
@@ -1,0 +1,220 @@
+/**
+ * @fileoverview Route tests for GET /api/stocks/quote/[symbol].
+ *
+ * The console this was written against was full of 500s for tickers that simply
+ * do not exist ("GOOH", "GOOGLE"), because any failure to produce a quote —
+ * including "no such stock" — was reported as a server fault. These tests pin
+ * the status codes: 400 for something that is not a ticker, 404 for a ticker
+ * with no data, and 500 reserved for an actual unexpected throw.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/packages/investing/src/stocks/unified-quote-service', () => ({
+  getQuote: vi.fn(),
+}))
+vi.mock('@/packages/investing/src/stocks/finnhub-wrapper', () => ({
+  finnhub: { getPeers: vi.fn(), getQuote: vi.fn() },
+}))
+
+import { NextRequest } from 'next/server'
+import { getQuote } from '@/packages/investing/src/stocks/unified-quote-service'
+import { finnhub } from '@/packages/investing/src/stocks/finnhub-wrapper'
+import { routeContext } from '../../__tests__/helpers/fake-db'
+import { GET } from '../quote/[symbol]/route'
+
+const mockGetQuote = getQuote as unknown as ReturnType<typeof vi.fn>
+const mockGetPeers = finnhub.getPeers as unknown as ReturnType<typeof vi.fn>
+const mockGetProfile = finnhub.getQuote as unknown as ReturnType<typeof vi.fn>
+
+/** A fully-populated quote as the unified service returns one. */
+const quoteFor = (symbol: string) => ({
+  success: true,
+  data: {
+    symbol,
+    price: 332.6,
+    change: 4.1,
+    changePercent: 1.25,
+    open: 330,
+    high: 334,
+    low: 329.5,
+    previousClose: 328.5,
+    volume: 23_510_000,
+    marketCap: 4_000_000_000_000,
+    currency: 'USD',
+    name: 'Alphabet Inc.',
+    exchange: 'NASDAQ',
+    timestamp: new Date('2026-09-11T20:00:00Z'),
+    source: 'yfinance' as const,
+  },
+})
+
+// The handler reads `request.nextUrl`, which only a NextRequest carries.
+const request = (symbol: string, search = '') =>
+  new NextRequest(`http://localhost/api/stocks/quote/${encodeURIComponent(symbol)}${search}`)
+
+const call = (symbol: string, search = '') =>
+  GET(request(symbol, search), routeContext({ symbol }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetPeers.mockResolvedValue({ success: true, peers: ['MSFT', 'AAPL'] })
+  mockGetProfile.mockResolvedValue({ success: true, data: {} })
+})
+
+describe('GET /api/stocks/quote/[symbol] — validation', () => {
+  it.each([
+    ['GOOGLE', 'INVALID_SYMBOL'],
+    ['NOT A SYMBOL', 'INVALID_SYMBOL'],
+    ['AAPL;DROP TABLE', 'INVALID_SYMBOL'],
+  ])('answers %s with 400 %s without calling a provider', async (symbol, code) => {
+    const res = await call(symbol)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ success: false, code })
+    expect(mockGetQuote).not.toHaveBeenCalled()
+  })
+
+  it.each(['GOO', 'GOOH', 'GOOHL'])(
+    'answers the partial ticker %s without calling a provider',
+    async (partial) => {
+      const res = await call(partial)
+
+      expect(res.status).toBe(404)
+      expect(mockGetQuote).not.toHaveBeenCalled()
+    },
+  )
+
+  it('answers an unlisted but well-formed ticker with 404', async () => {
+    const res = await call('ZZZZZ')
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toMatchObject({ code: 'SYMBOL_NOT_FOUND' })
+    expect(mockGetQuote).not.toHaveBeenCalled()
+  })
+
+  it('upper-cases the symbol before fetching', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+
+    await call('aapl')
+
+    expect(mockGetQuote).toHaveBeenCalledWith('AAPL', expect.anything())
+  })
+})
+
+describe('GET /api/stocks/quote/[symbol] — success', () => {
+  it('maps the normalized quote onto the price and summary blocks', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('GOOGL'))
+
+    const res = await call('GOOGL')
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toMatchObject({
+      success: true,
+      symbol: 'GOOGL',
+      source: 'yfinance',
+      data: {
+        price: {
+          regularMarketPrice: 332.6,
+          regularMarketChange: 4.1,
+          regularMarketChangePercent: 1.25,
+          longName: 'Alphabet Inc.',
+          exchange: 'NASDAQ',
+        },
+        summaryDetail: {
+          open: 330,
+          dayHigh: 334,
+          dayLow: 329.5,
+          previousClose: 328.5,
+          regularMarketVolume: 23_510_000,
+        },
+      },
+    })
+  })
+
+  it('attaches sector and industry from the bundled dataset', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+
+    const body = await (await call('AAPL')).json()
+
+    expect(body.data.price.sector).toBeTruthy()
+    expect(body.data.price.industry).toBeTruthy()
+  })
+
+  it('excludes the requested symbol from its own peer list', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+    mockGetPeers.mockResolvedValue({ success: true, peers: ['AAPL', 'MSFT'] })
+
+    const body = await (await call('AAPL')).json()
+
+    expect(body.data.peers).toEqual(['MSFT'])
+  })
+
+  it('bypasses the cache when live=true', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+
+    await call('AAPL', '?live=true')
+
+    expect(mockGetQuote).toHaveBeenCalledWith('AAPL', { useCache: false })
+  })
+
+  it('uses the cache by default', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+
+    await call('AAPL')
+
+    expect(mockGetQuote).toHaveBeenCalledWith('AAPL', { useCache: true })
+  })
+
+  it('still returns the quote when the peer lookup fails', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+    mockGetPeers.mockRejectedValue(new Error('finnhub down'))
+
+    const res = await call('AAPL')
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.peers).toEqual([])
+  })
+
+  it('still returns the quote when the profile lookup fails', async () => {
+    mockGetQuote.mockResolvedValue(quoteFor('AAPL'))
+    mockGetProfile.mockRejectedValue(new Error('finnhub down'))
+
+    expect((await call('AAPL')).status).toBe(200)
+  })
+})
+
+describe('GET /api/stocks/quote/[symbol] — upstream failures', () => {
+  it('answers 404, not 500, when no provider has data for a real ticker', async () => {
+    mockGetQuote.mockResolvedValue({ success: false, error: 'all sources failed' })
+
+    const res = await call('AAPL')
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      code: 'QUOTE_UNAVAILABLE',
+    })
+  })
+
+  it('answers 404 when the provider reports success with no payload', async () => {
+    mockGetQuote.mockResolvedValue({ success: true, data: undefined })
+
+    expect((await call('AAPL')).status).toBe(404)
+  })
+
+  it('answers 500 when the quote service throws unexpectedly', async () => {
+    mockGetQuote.mockRejectedValue(new Error('socket hang up'))
+
+    const res = await call('AAPL')
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({
+      success: false,
+      code: 'QUOTE_ERROR',
+      error: 'socket hang up',
+    })
+  })
+})

--- a/apps/ai-broker-web/app/api/stocks/__tests__/quotes-route.test.ts
+++ b/apps/ai-broker-web/app/api/stocks/__tests__/quotes-route.test.ts
@@ -1,0 +1,194 @@
+/**
+ * @fileoverview Route tests for GET /api/stocks/quotes, the batch endpoint the
+ * ticker strip polls. Each symbol costs a quote plus three historical fetches,
+ * so the symbol list is the blast radius of one request and is pinned here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+vi.mock('@/packages/investing/src/stocks/unified-quote-service', () => ({
+  getQuotes: vi.fn(),
+}))
+vi.mock('@/packages/investing/src/stocks/yahoo-finance-wrapper', () => ({
+  yahooFinanceWrapper: { getHistorical: vi.fn() },
+}))
+vi.mock('@/packages/investing/src/stocks/quote-cache-service', () => ({
+  quoteCacheService: { saveHistoricalQuotes: vi.fn() },
+}))
+
+import { getQuotes } from '@/packages/investing/src/stocks/unified-quote-service'
+import { yahooFinanceWrapper } from '@/packages/investing/src/stocks/yahoo-finance-wrapper'
+import { GET } from '../quotes/route'
+
+const mockGetQuotes = getQuotes as unknown as ReturnType<typeof vi.fn>
+const mockGetHistorical = yahooFinanceWrapper.getHistorical as unknown as ReturnType<typeof vi.fn>
+
+const quote = (symbol: string, price = 100) => ({
+  symbol,
+  name: `${symbol} Inc.`,
+  price,
+  change: 1,
+  changePercent: 1,
+  open: 99,
+  high: 101,
+  low: 98,
+  previousClose: 99,
+  volume: 1000,
+  marketCap: 1e12,
+  currency: 'USD',
+  exchange: 'NASDAQ',
+  timestamp: new Date('2026-09-11T20:00:00Z'),
+  source: 'yfinance' as const,
+})
+
+const call = (search: string) =>
+  GET(new NextRequest(`http://localhost/api/stocks/quotes${search}`))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetHistorical.mockResolvedValue({ success: false })
+})
+
+describe('GET /api/stocks/quotes — request shape', () => {
+  it('answers 400 when symbols is missing', async () => {
+    const res = await call('')
+
+    expect(res.status).toBe(400)
+    expect(mockGetQuotes).not.toHaveBeenCalled()
+  })
+
+  it('answers 400 when symbols is present but empty', async () => {
+    expect((await call('?symbols=')).status).toBe(400)
+    expect((await call('?symbols=,,,')).status).toBe(400)
+    expect(mockGetQuotes).not.toHaveBeenCalled()
+  })
+
+  it('upper-cases and trims each symbol', async () => {
+    mockGetQuotes.mockResolvedValue({
+      success: true,
+      data: { quotes: [quote('AAPL')], source: 'yfinance' },
+    })
+
+    await call('?symbols= aapl , msft &skipHistorical=true')
+
+    expect(mockGetQuotes).toHaveBeenCalledWith(['AAPL', 'MSFT'], expect.anything())
+  })
+
+  it('deduplicates repeated symbols', async () => {
+    mockGetQuotes.mockResolvedValue({
+      success: true,
+      data: { quotes: [quote('AAPL')], source: 'yfinance' },
+    })
+
+    await call('?symbols=AAPL,AAPL,aapl&skipHistorical=true')
+
+    expect(mockGetQuotes).toHaveBeenCalledWith(['AAPL'], expect.anything())
+  })
+
+  it('refuses a batch beyond the per-request ceiling', async () => {
+    const symbols = Array.from({ length: 51 }, (_, i) => `SYM${i}`).join(',')
+
+    const res = await call(`?symbols=${symbols}&skipHistorical=true`)
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ code: 'TOO_MANY_SYMBOLS' })
+    expect(mockGetQuotes).not.toHaveBeenCalled()
+  })
+
+  it('accepts a batch at exactly the ceiling', async () => {
+    const symbols = Array.from({ length: 50 }, (_, i) => `SY${i}`)
+    mockGetQuotes.mockResolvedValue({
+      success: true,
+      data: { quotes: symbols.map((s) => quote(s)), source: 'mixed' },
+    })
+
+    const res = await call(`?symbols=${symbols.join(',')}&skipHistorical=true`)
+
+    expect(res.status).toBe(200)
+    expect(mockGetQuotes).toHaveBeenCalled()
+  })
+})
+
+describe('GET /api/stocks/quotes — cache and enrichment options', () => {
+  beforeEach(() => {
+    mockGetQuotes.mockResolvedValue({
+      success: true,
+      data: { quotes: [quote('AAPL')], source: 'yfinance' },
+    })
+  })
+
+  it('uses the cache by default and bypasses it for live=true', async () => {
+    await call('?symbols=AAPL&skipHistorical=true')
+    expect(mockGetQuotes).toHaveBeenLastCalledWith(['AAPL'], { useCache: true, cacheTTL: undefined })
+
+    await call('?symbols=AAPL&live=true&skipHistorical=true')
+    expect(mockGetQuotes).toHaveBeenLastCalledWith(['AAPL'], { useCache: false, cacheTTL: undefined })
+  })
+
+  it('passes a numeric cacheTTL through', async () => {
+    await call('?symbols=AAPL&cacheTTL=300000&skipHistorical=true')
+
+    expect(mockGetQuotes).toHaveBeenCalledWith(['AAPL'], { useCache: true, cacheTTL: 300000 })
+  })
+
+  it('skips the historical lookups when skipHistorical=true', async () => {
+    await call('?symbols=AAPL&skipHistorical=true')
+
+    expect(mockGetHistorical).not.toHaveBeenCalled()
+  })
+
+  it('reports zeroed period changes when historical data is skipped', async () => {
+    const body = await (await call('?symbols=AAPL&skipHistorical=true')).json()
+
+    expect(body.data[0]).toMatchObject({
+      symbol: 'AAPL',
+      weeklyChange: 0,
+      monthlyChange: 0,
+      yearlyChange: 0,
+    })
+  })
+
+  it('computes period changes from historical bars when not skipped', async () => {
+    mockGetHistorical.mockResolvedValue({
+      success: true,
+      data: [
+        { date: new Date('2026-09-01'), open: 90, high: 91, low: 89, close: 90, volume: 1 },
+        { date: new Date('2026-09-11'), open: 99, high: 100, low: 98, close: 99, volume: 1 },
+      ],
+    })
+
+    const body = await (await call('?symbols=AAPL')).json()
+
+    expect(body.data[0].weeklyChange).toBeCloseTo(9, 2)
+    expect(body.data[0].weeklyChangePercent).toBe(10)
+  })
+
+  it('still returns quotes when the historical lookup throws', async () => {
+    mockGetHistorical.mockRejectedValue(new Error('yahoo down'))
+
+    const res = await call('?symbols=AAPL')
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ success: true })
+  })
+})
+
+describe('GET /api/stocks/quotes — failures', () => {
+  it('answers 400 when the quote service reports failure', async () => {
+    mockGetQuotes.mockResolvedValue({ success: false, error: 'no sources' })
+
+    const res = await call('?symbols=AAPL&skipHistorical=true')
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ success: false, error: 'no sources' })
+  })
+
+  it('answers 500 when the quote service throws', async () => {
+    mockGetQuotes.mockRejectedValue(new Error('socket hang up'))
+
+    const res = await call('?symbols=AAPL&skipHistorical=true')
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({ error: 'socket hang up' })
+  })
+})

--- a/apps/ai-broker-web/app/api/stocks/__tests__/search-routes.test.ts
+++ b/apps/ai-broker-web/app/api/stocks/__tests__/search-routes.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview Route tests for the two lookup endpoints a search box calls:
+ * /api/stocks/autocomplete (local dataset) and /api/stocks/search (Yahoo).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+const yahooSearch = vi.hoisted(() => vi.fn())
+
+vi.mock('yahoo-finance2', () => ({
+  default: class {
+    search = yahooSearch
+  },
+}))
+
+import { GET as autocompleteRoute } from '../autocomplete/route'
+import { GET as searchRoute } from '../search/route'
+
+const autocompleteCall = (query: string) =>
+  autocompleteRoute(new NextRequest(`http://localhost/api/stocks/autocomplete${query}`))
+
+const searchCall = (query: string) =>
+  searchRoute(new NextRequest(`http://localhost/api/stocks/search${query}`))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/stocks/autocomplete', () => {
+  it('returns an empty list for a missing query rather than an error', async () => {
+    const res = await autocompleteCall('')
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ success: true, data: [] })
+  })
+
+  it('matches on a symbol prefix', async () => {
+    const body = await (await autocompleteCall('?q=aapl')).json()
+
+    expect(body.success).toBe(true)
+    expect(body.data.some((row: any) => row.symbol === 'AAPL')).toBe(true)
+  })
+
+  it('matches on a substring of the company name', async () => {
+    const body = await (await autocompleteCall('?q=alphabet')).json()
+
+    expect(body.data.length).toBeGreaterThan(0)
+    expect(
+      body.data.every((row: any) =>
+        `${row.symbol} ${row.name}`.toLowerCase().includes('alphabet'),
+      ),
+    ).toBe(true)
+  })
+
+  it('is case-insensitive', async () => {
+    const lower = await (await autocompleteCall('?q=aapl')).json()
+    const upper = await (await autocompleteCall('?q=AAPL')).json()
+
+    expect(upper.data).toEqual(lower.data)
+  })
+
+  it('returns ten suggestions by default', async () => {
+    const body = await (await autocompleteCall('?q=a')).json()
+
+    expect(body.data).toHaveLength(10)
+  })
+
+  it('honors an explicit limit', async () => {
+    const body = await (await autocompleteCall('?q=a&limit=3')).json()
+
+    expect(body.data).toHaveLength(3)
+  })
+
+  it('falls back to the default when the limit is not a number', async () => {
+    // `parseInt('abc')` is NaN, and `length >= NaN` is never true, so an
+    // unguarded limit let this walk the whole dataset into the response.
+    const body = await (await autocompleteCall('?q=a&limit=abc')).json()
+
+    expect(body.data).toHaveLength(10)
+  })
+
+  it('clamps a limit above the ceiling', async () => {
+    const body = await (await autocompleteCall('?q=a&limit=100000')).json()
+
+    expect(body.data.length).toBeLessThanOrEqual(50)
+  })
+
+  it('clamps a zero or negative limit to at least one result', async () => {
+    expect((await (await autocompleteCall('?q=a&limit=0')).json()).data).toHaveLength(1)
+    expect((await (await autocompleteCall('?q=a&limit=-5')).json()).data).toHaveLength(1)
+  })
+
+  it('returns an empty list for a query that matches nothing', async () => {
+    const body = await (await autocompleteCall('?q=zzzzzznotaticker')).json()
+
+    expect(body.data).toEqual([])
+    expect(body.count).toBe(0)
+  })
+})
+
+describe('GET /api/stocks/search', () => {
+  it('answers 400 MISSING_QUERY when q is absent', async () => {
+    const res = await searchCall('')
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ code: 'MISSING_QUERY' })
+    expect(yahooSearch).not.toHaveBeenCalled()
+  })
+
+  it('returns the provider quotes with a count', async () => {
+    yahooSearch.mockResolvedValue({
+      quotes: [{ symbol: 'AAPL' }, { symbol: 'AAPLW' }],
+    })
+
+    const res = await searchCall('?q=apple')
+    const body = await res.json()
+
+    expect(res.status).toBe(200)
+    expect(body).toMatchObject({ success: true, query: 'apple', count: 2 })
+    expect(yahooSearch).toHaveBeenCalledWith('apple')
+  })
+
+  it('reports a zero count when the provider returns no quotes', async () => {
+    yahooSearch.mockResolvedValue({})
+
+    const body = await (await searchCall('?q=nothing')).json()
+
+    expect(body.count).toBe(0)
+  })
+
+  it('answers 500 SEARCH_ERROR when the provider throws', async () => {
+    yahooSearch.mockRejectedValue(new Error('yahoo down'))
+
+    const res = await searchCall('?q=apple')
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'SEARCH_ERROR',
+      error: 'yahoo down',
+    })
+  })
+})

--- a/apps/ai-broker-web/app/api/stocks/autocomplete/route.ts
+++ b/apps/ai-broker-web/app/api/stocks/autocomplete/route.ts
@@ -5,11 +5,23 @@ import { stockNames } from "investing/stocks";
 // Use the imported stock names data directly
 const stockCache = stockNames;
 
+/** Suggestions returned when the caller names no limit. */
+const DEFAULT_AUTOCOMPLETE_RESULTS = 10;
+/** Ceiling on suggestions; a typeahead dropdown cannot use more than this. */
+const MAX_AUTOCOMPLETE_RESULTS = 50;
+
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const query = searchParams.get("q")?.toLowerCase();
-    const limit = parseInt(searchParams.get("limit") || "10");
+
+    // Clamp the limit. `parseInt` on a non-numeric value yields NaN, and every
+    // `results.length >= NaN` comparison is false, so the loop used to run to
+    // the end of the dataset and return thousands of rows to a typeahead.
+    const parsedLimit = Number.parseInt(searchParams.get("limit") || "", 10);
+    const limit = Number.isFinite(parsedLimit)
+      ? Math.min(Math.max(parsedLimit, 1), MAX_AUTOCOMPLETE_RESULTS)
+      : DEFAULT_AUTOCOMPLETE_RESULTS;
 
     if (!query || query.length < 1) {
       return NextResponse.json({ success: true, data: [] });

--- a/apps/ai-broker-web/app/api/stocks/historical/[symbol]/route.ts
+++ b/apps/ai-broker-web/app/api/stocks/historical/[symbol]/route.ts
@@ -2,6 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { FinnhubWrapper } from '@/packages/investing/src/stocks/finnhub-wrapper';
 import { quoteCacheService } from '@/packages/investing/src/stocks/quote-cache-service';
+import { validateSymbol } from '@/lib/stocks/symbol';
 
 const finnhub = new FinnhubWrapper();
 
@@ -12,7 +13,25 @@ export async function GET(
     let symbol = '';
     try {
         const paramsValue = await params;
-        symbol = paramsValue.symbol;
+
+        // Partial tickers from a search box ("GOO" on the way to "GOOGL") used
+        // to reach the upstream providers and come back as a 404 only after the
+        // round-trip. Rejecting them here makes the answer immediate and
+        // distinguishes "not a ticker" (400) from "no data" (404).
+        const validation = validateSymbol(paramsValue.symbol);
+        if (!validation.ok) {
+            return NextResponse.json(
+                {
+                    success: false,
+                    error: validation.error,
+                    code: validation.code,
+                    timestamp: new Date().toISOString()
+                },
+                { status: validation.status }
+            );
+        }
+        symbol = validation.symbol;
+
         const { searchParams } = new URL(request.url);
 
         // Get parameters with defaults
@@ -100,9 +119,15 @@ export async function GET(
                 endDateStr
             );
 
-            // If we have enough cached data (at least 80% of expected), use it
-            const expectedDays = Math.floor((new Date(endDateStr).getTime() - new Date(startDateStr).getTime()) / (1000 * 60 * 60 * 24));
-            if (cachedQuotes.length >= expectedDays * 0.8) {
+            // Decide whether the cache covers the window. The comparison has to
+            // be against *trading* days: markets are open ~5 of every 7 days, so
+            // a complete year of bars is only ~69% of the calendar days in it and
+            // would never clear a threshold measured against calendar days.
+            const calendarDays = Math.floor(
+                (new Date(endDateStr).getTime() - new Date(startDateStr).getTime()) / (1000 * 60 * 60 * 24)
+            );
+            const expectedTradingDays = Math.floor((calendarDays * 5) / 7);
+            if (expectedTradingDays > 0 && cachedQuotes.length >= expectedTradingDays * 0.8) {
                 console.log(`Using ${cachedQuotes.length} cached quotes for ${symbol}`);
                 return NextResponse.json({
                     success: true,

--- a/apps/ai-broker-web/app/api/stocks/quote/[symbol]/route.ts
+++ b/apps/ai-broker-web/app/api/stocks/quote/[symbol]/route.ts
@@ -1,6 +1,7 @@
 // Stock Quote API Route - Using Unified Quote Service
 import { NextRequest, NextResponse } from "next/server";
 import { getQuote } from "@/packages/investing/src/stocks/unified-quote-service";
+import { validateSymbol } from "@/lib/stocks/symbol";
 import { finnhub } from "@/packages/investing/src/stocks/finnhub-wrapper";
 import stockNamesData from "@/packages/investing/src/stock-names-data/stock-names.json";
 import sectorsIndustriesData from "@/packages/investing/src/stock-names-data/sectors-industries.json";
@@ -66,7 +67,26 @@ export async function GET(
   { params }: { params: Promise<{ symbol: string }> },
 ) {
   try {
-    const { symbol } = await params;
+    const { symbol: rawSymbol } = await params;
+
+    // Reject malformed and unknown tickers before touching a data provider: a
+    // search box sends a request per keystroke, and every partial ticker on the
+    // way to a real one would otherwise cost an upstream call and surface as a
+    // 500 in the browser console.
+    const validation = validateSymbol(rawSymbol);
+    if (!validation.ok) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: validation.error,
+          code: validation.code,
+          timestamp: new Date().toISOString(),
+        },
+        { status: validation.status },
+      );
+    }
+    const symbol = validation.symbol;
+
     const searchParams = request.nextUrl.searchParams;
     const liveParam = searchParams.get("live");
     const useCache = liveParam !== "true"; // Use cache by default, bypass if live=true
@@ -75,14 +95,16 @@ export async function GET(
     const quoteResult = await getQuote(symbol, { useCache });
 
     if (!quoteResult.success || !quoteResult.data) {
+      // The ticker is real but no provider had data for it. That is a missing
+      // resource, not a server fault, so it must not be a 500.
       return NextResponse.json(
         {
           success: false,
-          error: quoteResult.error || "Failed to fetch quote",
-          code: "QUOTE_ERROR",
+          error: quoteResult.error || `No quote data available for ${symbol}`,
+          code: "QUOTE_UNAVAILABLE",
           timestamp: new Date().toISOString(),
         },
-        { status: 500 },
+        { status: 404 },
       );
     }
 

--- a/apps/ai-broker-web/app/api/stocks/quotes/route.ts
+++ b/apps/ai-broker-web/app/api/stocks/quotes/route.ts
@@ -6,6 +6,9 @@ import { quoteCacheService } from "@/packages/investing/src/stocks/quote-cache-s
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/** Upper bound on symbols per batch request. */
+const MAX_SYMBOLS_PER_REQUEST = 50;
+
 /**
  * Calculate weekly change from historical data (last 5 trading days)
  */
@@ -153,7 +156,35 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    const symbols = symbolsParam.split(",").map((s) => s.trim().toUpperCase());
+    // Each symbol costs a quote plus, unless skipped, three historical fetches,
+    // all issued per symbol. Without a ceiling one request could fan out into
+    // thousands of upstream calls and time out.
+    const requestedSymbols = symbolsParam
+      .split(",")
+      .map((s) => s.trim().toUpperCase())
+      .filter(Boolean);
+
+    const uniqueSymbols = [...new Set(requestedSymbols)];
+
+    if (uniqueSymbols.length === 0) {
+      return NextResponse.json(
+        { success: false, error: "symbols parameter is required" },
+        { status: 400 },
+      );
+    }
+
+    if (uniqueSymbols.length > MAX_SYMBOLS_PER_REQUEST) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `Too many symbols: ${uniqueSymbols.length}. The maximum is ${MAX_SYMBOLS_PER_REQUEST} per request.`,
+          code: "TOO_MANY_SYMBOLS",
+        },
+        { status: 400 },
+      );
+    }
+
+    const symbols = uniqueSymbols;
 
     // Use unified quote service with fallback
     const result = await getQuotes(symbols, { useCache, cacheTTL });

--- a/apps/ai-broker-web/app/api/user/__tests__/settings-route.test.ts
+++ b/apps/ai-broker-web/app/api/user/__tests__/settings-route.test.ts
@@ -20,7 +20,7 @@ const mockGetSession = auth.api.getSession as unknown as ReturnType<typeof vi.fn
 /** Point the mocked `db` module at a fresh fake for this test. */
 function setupDb(options: Parameters<typeof createFakeDb>[0] = {}) {
   const fake = createFakeDb(options)
-  Object.assign(db as Record<string, unknown>, fake)
+  Object.assign(db as unknown as Record<string, unknown>, fake)
   return fake
 }
 
@@ -143,7 +143,7 @@ describe('GET /api/user/settings — payload', () => {
   })
 
   it('answers 500 when the lookup throws', async () => {
-    Object.assign(db as Record<string, unknown>, {
+    Object.assign(db as unknown as Record<string, unknown>, {
       query: {
         userSettings: {
           findFirst: () => Promise.reject(new Error('D1 unavailable')),

--- a/apps/ai-broker-web/app/api/user/__tests__/settings-route.test.ts
+++ b/apps/ai-broker-web/app/api/user/__tests__/settings-route.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @fileoverview Route tests for /api/user/settings.
+ *
+ * The 401 in the browser console is the correct answer for a signed-out
+ * visitor, so what matters here is that the route is consistent about it and
+ * never leaks a stored provider key back to the client.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/lib/db', () => ({ db: {} }))
+vi.mock('@/lib/auth', () => ({ auth: { api: { getSession: vi.fn() } } }))
+
+import { db } from '@/lib/db'
+import { auth } from '@/lib/auth'
+import { createFakeDb, jsonRequest } from '../../__tests__/helpers/fake-db'
+import { GET, POST } from '../settings/route'
+
+const mockGetSession = auth.api.getSession as unknown as ReturnType<typeof vi.fn>
+
+/** Point the mocked `db` module at a fresh fake for this test. */
+function setupDb(options: Parameters<typeof createFakeDb>[0] = {}) {
+  const fake = createFakeDb(options)
+  Object.assign(db as Record<string, unknown>, fake)
+  return fake
+}
+
+const getRequest = () => jsonRequest('http://localhost/api/user/settings', 'GET')
+const postRequest = (body: unknown) =>
+  jsonRequest('http://localhost/api/user/settings', 'POST', body)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetSession.mockResolvedValue({ user: { id: 'user-1' } })
+})
+
+describe('GET /api/user/settings — authentication', () => {
+  it('answers 401 when there is no session', async () => {
+    mockGetSession.mockResolvedValue(null)
+    setupDb()
+
+    const res = await GET(getRequest())
+
+    expect(res.status).toBe(401)
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' })
+  })
+
+  it('answers 401 when the session carries no user', async () => {
+    mockGetSession.mockResolvedValue({ user: null })
+    setupDb()
+
+    expect((await GET(getRequest())).status).toBe(401)
+  })
+
+  it('reads the session from the request headers', async () => {
+    setupDb()
+    const request = getRequest()
+
+    await GET(request)
+
+    expect(mockGetSession).toHaveBeenCalledWith({ headers: request.headers })
+  })
+})
+
+describe('GET /api/user/settings — payload', () => {
+  it('masks every stored provider secret', async () => {
+    setupDb({
+      query: {
+        userSettings: {
+          findFirst: {
+            userId: 'user-1',
+            groqApiKey: 'gsk_real_secret',
+            openaiApiKey: 'sk-real-secret',
+            anthropicApiKey: 'sk-ant-real',
+            alpacaApiSecret: 'alpaca-real',
+            robinhoodPassword: 'hunter2',
+            theme: 'dark',
+          },
+        },
+        users: { findFirst: { apiKey: 'broker-key' } },
+      },
+    })
+
+    const body = await (await GET(getRequest())).json()
+
+    for (const field of [
+      'groqApiKey',
+      'openaiApiKey',
+      'anthropicApiKey',
+      'alpacaApiSecret',
+      'robinhoodPassword',
+    ]) {
+      expect(body[field]).toBe('••••••••')
+    }
+    expect(JSON.stringify(body)).not.toMatch(/real|hunter2/)
+  })
+
+  it('reports an unset secret as null rather than a mask', async () => {
+    setupDb({
+      query: {
+        userSettings: { findFirst: { userId: 'user-1', groqApiKey: null } },
+        users: { findFirst: { apiKey: 'broker-key' } },
+      },
+    })
+
+    const body = await (await GET(getRequest())).json()
+
+    expect(body.groqApiKey).toBeNull()
+  })
+
+  it('passes non-secret settings through untouched', async () => {
+    setupDb({
+      query: {
+        userSettings: { findFirst: { userId: 'user-1', theme: 'dark', uiConfig: '{"a":1}' } },
+        users: { findFirst: { apiKey: 'broker-key' } },
+      },
+    })
+
+    const body = await (await GET(getRequest())).json()
+
+    expect(body).toMatchObject({ theme: 'dark', uiConfig: '{"a":1}', apiKey: 'broker-key' })
+  })
+
+  it('returns just the API key when the user has no settings row yet', async () => {
+    setupDb({
+      query: {
+        userSettings: { findFirst: undefined },
+        users: { findFirst: { apiKey: 'broker-key' } },
+      },
+    })
+
+    const res = await GET(getRequest())
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ apiKey: 'broker-key' })
+  })
+
+  it('reports a null API key when the user profile has none', async () => {
+    setupDb({
+      query: { userSettings: { findFirst: undefined }, users: { findFirst: undefined } },
+    })
+
+    await expect((await GET(getRequest())).json()).resolves.toEqual({ apiKey: null })
+  })
+
+  it('answers 500 when the lookup throws', async () => {
+    Object.assign(db as Record<string, unknown>, {
+      query: {
+        userSettings: {
+          findFirst: () => Promise.reject(new Error('D1 unavailable')),
+        },
+      },
+    })
+
+    const res = await GET(getRequest())
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to fetch settings' })
+  })
+})
+
+describe('POST /api/user/settings', () => {
+  it('answers 401 when there is no session', async () => {
+    mockGetSession.mockResolvedValue(null)
+    setupDb()
+
+    const res = await POST(postRequest({ theme: 'dark' }))
+
+    expect(res.status).toBe(401)
+  })
+
+  it('updates the existing row when one is present', async () => {
+    const fake = setupDb({
+      query: { userSettings: { findFirst: { userId: 'user-1' } } },
+    })
+
+    const res = await POST(postRequest({ theme: 'dark' }))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ success: true })
+    expect(fake.calls.update).toBeDefined()
+    expect(fake.calls.insert).toBeUndefined()
+  })
+
+  it('inserts a new row when the user has no settings yet', async () => {
+    const fake = setupDb({ query: { userSettings: { findFirst: undefined } } })
+
+    const res = await POST(postRequest({ theme: 'dark' }))
+
+    expect(res.status).toBe(200)
+    expect(fake.calls.insert).toBeDefined()
+    expect(fake.calls.update).toBeUndefined()
+  })
+
+  it('stamps updatedAt on an update', async () => {
+    const fake = setupDb({ query: { userSettings: { findFirst: { userId: 'user-1' } } } })
+
+    await POST(postRequest({ theme: 'dark' }))
+
+    expect(fake.calls.set[0][0]).toMatchObject({ theme: 'dark', updatedAt: expect.any(Date) })
+  })
+
+  it('answers 500 on a malformed JSON body', async () => {
+    setupDb()
+    const request = new Request('http://localhost/api/user/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{ not json',
+    }) as any
+
+    const res = await POST(request)
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to save settings' })
+  })
+})

--- a/apps/ai-broker-web/app/page.tsx
+++ b/apps/ai-broker-web/app/page.tsx
@@ -2,6 +2,7 @@ import { HeroSection } from "@/components/landing/hero-section"
 import { TickerTape } from "@/components/landing/ticker-tape"
 import { FeatureStorySection } from "@/components/landing/feature-story-section"
 import { AgentsTeamSection } from "@/components/landing/agents-team-section"
+import { VideoShowcaseSection } from "@/components/landing/video-showcase-section"
 import { PlatformBentoSection } from "@/components/landing/platform-bento-section"
 import { PredictionMarketsPreview } from "@/components/landing/prediction-markets-preview"
 import { BrokersGridSection } from "@/components/landing/brokers-grid-section"
@@ -31,6 +32,7 @@ export default function LandingPage() {
       />
 
       <AgentsTeamSection />
+      <VideoShowcaseSection />
       <PlatformBentoSection />
       <PredictionMarketsPreview />
       <BrokersGridSection />

--- a/apps/ai-broker-web/components/investing/charts/dynamic-stock-chart.tsx
+++ b/apps/ai-broker-web/components/investing/charts/dynamic-stock-chart.tsx
@@ -5,7 +5,7 @@ import { Chart, CandlestickSeries, LineSeries, HistogramSeries, AreaSeries, Time
 import { Button } from "@/components/ui/button"
 import { rsi, macd, atr, stochasticOscillator, cci, obv } from "indicatorts"
 import { TagInput, Tag } from "@/components/ui/tag-input"
-import { Loader2, CandlestickChart, TrendingUp } from "lucide-react"
+import { Loader2, CandlestickChart, TrendingUp, ChevronDown, ChevronRight } from "lucide-react"
 import { setStateInURL } from "@/lib/utils"
 import { type IChartApi, type Time, type LogicalRange } from "lightweight-charts"
 import grab from 'grab-url';
@@ -47,6 +47,12 @@ const INDICATOR_SUGGESTIONS: Tag[] = [
 
 type ChartType = "candlestick" | "line" | "area"
 
+/**
+ * Table rows at or below this height are the separators lightweight-charts
+ * draws between panes, not panes themselves.
+ */
+const SEPARATOR_MAX_HEIGHT = 10
+
 export function DynamicStockChart({
   symbol,
   initialRange = "1y",
@@ -55,6 +61,12 @@ export function DynamicStockChart({
 }: DynamicStockChartProps) {
   const [activeTags, setActiveTags] = useState<Tag[]>([])
   const [showVolume, setShowVolume] = useState(true)
+  // Ids of the panes below the price chart the user has folded away.
+  const [collapsedPanes, setCollapsedPanes] = useState<Set<string>>(new Set())
+  // Pixel offset and height of each rendered pane, read back from the chart so
+  // the labels sit on the pane they name instead of being guessed from the
+  // stretch factors.
+  const [paneLayout, setPaneLayout] = useState<{ top: number; height: number }[]>([])
   const [chartType, setChartType] = useState<ChartType>("candlestick")
   const [selectedRange, setSelectedRange] = useState(initialRange)
   const [secondaryData, setSecondaryData] = useState<Record<string, ChartData[]>>({})
@@ -67,6 +79,7 @@ export function DynamicStockChart({
   const lineSeriesRef = useRef<any>(null)
   const areaSeriesRef = useRef<any>(null)
   const chartRef = useRef<any>(null)
+  const chartWrapperRef = useRef<HTMLDivElement>(null)
   const lastSymbol = useRef<string>(symbol)
 
   // Fetch initial data on mount or symbol change
@@ -261,6 +274,74 @@ export function DynamicStockChart({
     }
   }, [loadingMore, symbol, chartData]);
 
+  /**
+   * Pick the bar size that suits a visible window of `spanDays`.
+   *
+   * Zooming does not change the data underneath it, so a chart loaded at daily
+   * bars stays daily however far in you go — past a few weeks the candles are
+   * just stretched apart with nothing between them. Matching the interval to
+   * the span means zooming in actually resolves more detail.
+   */
+  const intervalForSpan = (spanDays: number): string => {
+    if (spanDays <= 2) return "5m"
+    if (spanDays <= 10) return "15m"
+    if (spanDays <= 60) return "1h"
+    if (spanDays <= 365 * 3) return "1d"
+    return "1wk"
+  }
+
+  /** Bar size currently loaded; starts at the caller's choice. */
+  const loadedInterval = useRef<string>(interval)
+  const zoomFetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const zoomFetchController = useRef<AbortController | null>(null)
+
+  /**
+   * Reload the visible window at `nextInterval`. Requests the exact window on
+   * screen rather than a named range, so the bars returned are the ones being
+   * looked at.
+   */
+  const refetchForZoom = useCallback(async (fromSec: number, toSec: number, nextInterval: string) => {
+    zoomFetchController.current?.abort()
+    const controller = new AbortController()
+    zoomFetchController.current = controller
+
+    setLoadingMore(true)
+    try {
+      const res = await fetch(
+        `/api/stocks/historical/${encodeURIComponent(symbol)}?interval=${nextInterval}&period1=${Math.floor(fromSec)}&period2=${Math.ceil(toSec)}`,
+        { signal: controller.signal }
+      )
+      const json = await res.json()
+      if (controller.signal.aborted) return
+
+      const dataArray = Array.isArray(json.data?.data) ? json.data.data :
+        Array.isArray(json.data) ? json.data : null
+
+      if (json.success && dataArray && dataArray.length > 0) {
+        const rebased: ChartData[] = dataArray.map((d: any) => ({
+          date: d.date || d.time,
+          open: d.open,
+          high: d.high,
+          low: d.low,
+          close: d.close,
+          volume: d.volume
+        })).filter((d: ChartData) => d.open && d.close)
+
+        if (rebased.length > 0) {
+          loadedInterval.current = nextInterval
+          // Replacing the series re-runs the indicator memos against the new
+          // bars, so RSI/MACD/etc. are recomputed at the zoomed resolution.
+          setChartData(rebased.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()))
+        }
+      }
+    } catch (e) {
+      if ((e as Error)?.name === "AbortError") return
+      console.error("[DynamicStockChart] Zoom refetch failed", e)
+    } finally {
+      if (!controller.signal.aborted) setLoadingMore(false)
+    }
+  }, [symbol])
+
   // Handler for visible range changes
   const onVisibleRangeChange = (range: LogicalRange | null) => {
     if (!range || !candlestickSeriesRef.current || chartData.length === 0) return;
@@ -276,7 +357,36 @@ export function DynamicStockChart({
         fetchMoreData(firstTime);
       }
     }
+
+    // Re-resolve the data to the zoom level, once the zooming settles. Wheel
+    // events fire continuously, so without the delay this would issue a request
+    // per notch.
+    const firstIndex = Math.max(0, Math.floor(range.from))
+    const lastIndex = Math.min(chartData.length - 1, Math.ceil(range.to))
+    if (lastIndex <= firstIndex) return
+
+    const fromSec = new Date(chartData[firstIndex].date).getTime() / 1000
+    const toSec = new Date(chartData[lastIndex].date).getTime() / 1000
+    const spanDays = (toSec - fromSec) / 86400
+    if (!Number.isFinite(spanDays) || spanDays <= 0) return
+
+    const nextInterval = intervalForSpan(spanDays)
+    if (nextInterval === loadedInterval.current) return
+
+    if (zoomFetchTimer.current) clearTimeout(zoomFetchTimer.current)
+    zoomFetchTimer.current = setTimeout(() => {
+      refetchForZoom(fromSec, toSec, nextInterval)
+    }, 400)
   };
+
+  // Drop any pending zoom work when the symbol or requested range changes.
+  useEffect(() => {
+    loadedInterval.current = interval
+    return () => {
+      if (zoomFetchTimer.current) clearTimeout(zoomFetchTimer.current)
+      zoomFetchController.current?.abort()
+    }
+  }, [symbol, selectedRange, interval])
 
   const times = useMemo(() => chartData.map(d => Math.floor(new Date(d.date).getTime() / 1000) as Time), [chartData])
 
@@ -412,6 +522,89 @@ export function DynamicStockChart({
       })
   }, [activeTags, secondaryData, symbol])
 
+  /**
+   * Bumped whenever the chart should re-fit to its content: a new symbol,
+   * range, indicator set or chart type. Deliberately not bumped when a zoom
+   * refetch swaps the bars, so the zoom survives.
+   */
+  const [fitKey, setFitKey] = useState(0)
+
+  useEffect(() => {
+    setFitKey(key => key + 1)
+  }, [symbol, selectedRange, interval, activeTags.length, showVolume, chartType, collapsedPanes.size])
+
+  /**
+   * The panes stacked under the price chart, in render order: volume first when
+   * shown, then one per active indicator. Each carries the label drawn on it
+   * and whether the user has folded it away.
+   */
+  const bottomPanes = useMemo(() => {
+    const panes: { id: string; label: string }[] = []
+    if (showVolume) panes.push({ id: "volume", label: "Volume" })
+    for (const indicator of indicatorSeries as any[]) {
+      panes.push({ id: indicator.id, label: indicator.name })
+    }
+    return panes
+  }, [showVolume, indicatorSeries])
+
+  const visiblePanes = useMemo(
+    () => bottomPanes.filter(pane => !collapsedPanes.has(pane.id)),
+    [bottomPanes, collapsedPanes]
+  )
+
+  const togglePane = useCallback((id: string) => {
+    setCollapsedPanes(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  /**
+   * Measure where each pane actually sits, so a label can be drawn on it.
+   *
+   * The heights are read from the chart's own layout rather than derived from
+   * the stretch factors: the time axis and the one-pixel separators between
+   * panes take space the ratios do not account for, so computed positions drift
+   * further down the stack. lightweight-charts lays the panes out as table rows
+   * — the tall ones are panes, the 1px ones separators — and the last tall row
+   * is the time axis, which is not a pane and is dropped.
+   */
+  const measurePanes = useCallback(() => {
+    const wrapper = chartWrapperRef.current
+    const table = wrapper?.querySelector("table")
+    if (!wrapper || !table) return
+
+    const wrapperTop = wrapper.getBoundingClientRect().top
+    const rows = Array.from(table.querySelectorAll("tr"))
+      .map(row => row.getBoundingClientRect())
+      .filter(rect => rect.height > SEPARATOR_MAX_HEIGHT)
+
+    setPaneLayout(
+      rows.slice(0, -1).map(rect => ({ top: rect.top - wrapperTop, height: rect.height }))
+    )
+  }, [])
+
+  useEffect(() => {
+    if (chartData.length === 0) return
+
+    // The chart lays out after this render, and settles over a frame or two
+    // while it sizes its canvases, so measure again shortly after.
+    const frame = requestAnimationFrame(measurePanes)
+    const settle = setTimeout(measurePanes, 250)
+
+    const wrapper = chartWrapperRef.current
+    const observer = wrapper ? new ResizeObserver(measurePanes) : null
+    if (wrapper && observer) observer.observe(wrapper)
+
+    return () => {
+      cancelAnimationFrame(frame)
+      clearTimeout(settle)
+      observer?.disconnect()
+    }
+  }, [measurePanes, chartData.length, visiblePanes.length, chartType])
+
   const chartOptions = {
     layout: {
       background: { color: "transparent" },
@@ -517,11 +710,11 @@ export function DynamicStockChart({
       )}
 
       {/* Chart */}
-      <div className="relative border rounded-lg overflow-hidden bg-card">
+      <div ref={chartWrapperRef} className="relative border rounded-lg overflow-hidden bg-card">
         {chartData.length > 0 ? (
           <Chart
             ref={chartRef}
-            key={`chart-${showVolume}-${activeTags.length}-${chartType}`}
+            key={`chart-${showVolume}-${activeTags.length}-${chartType}-${visiblePanes.length}`}
             options={chartOptions}
           >
 
@@ -563,38 +756,50 @@ export function DynamicStockChart({
               ))}
             </Pane>
 
-            {showVolume && (
-              <Pane stretchFactor={1}>
-                <HistogramSeries
-                  data={volumeData}
-                  options={{ priceFormat: { type: "volume" } }}
-                />
-              </Pane>
-            )}
+            {/* Panes under the price chart, in the order `bottomPanes` lists
+                them so the measured layout lines up with the labels. */}
+            {visiblePanes.map(pane => {
+              if (pane.id === "volume") {
+                return (
+                  <Pane key="volume" stretchFactor={1}>
+                    <HistogramSeries
+                      data={volumeData}
+                      options={{ priceFormat: { type: "volume" } }}
+                    />
+                  </Pane>
+                )
+              }
 
-            {indicatorSeries.map((indicator: any) => (
-              <Pane key={indicator.id} stretchFactor={1}>
-                {indicator.type === "macd" ? (
-                  <>
-                    <LineSeries data={indicator.data.macd} options={{ color: "#2196F3", lineWidth: 1 }} />
-                    <LineSeries data={indicator.data.signal} options={{ color: "#FF9800", lineWidth: 1 }} />
-                    <HistogramSeries data={indicator.data.histogram} />
-                  </>
-                ) : indicator.type === "stochastic" ? (
-                  <>
-                    <LineSeries data={indicator.data.k} options={{ color: "#2196F3", lineWidth: 1 }} />
-                    <LineSeries data={indicator.data.d} options={{ color: "#FF9800", lineWidth: 1 }} />
-                  </>
-                ) : (
-                  <LineSeries data={indicator.data} options={indicator.options as any} />
-                )}
-              </Pane>
-            ))}
+              const indicator = (indicatorSeries as any[]).find(i => i.id === pane.id)
+              if (!indicator) return null
+
+              return (
+                <Pane key={indicator.id} stretchFactor={1}>
+                  {indicator.type === "macd" ? (
+                    <>
+                      <LineSeries data={indicator.data.macd} options={{ color: "#2196F3", lineWidth: 1 }} />
+                      <LineSeries data={indicator.data.signal} options={{ color: "#FF9800", lineWidth: 1 }} />
+                      <HistogramSeries data={indicator.data.histogram} />
+                    </>
+                  ) : indicator.type === "stochastic" ? (
+                    <>
+                      <LineSeries data={indicator.data.k} options={{ color: "#2196F3", lineWidth: 1 }} />
+                      <LineSeries data={indicator.data.d} options={{ color: "#FF9800", lineWidth: 1 }} />
+                    </>
+                  ) : (
+                    <LineSeries data={indicator.data} options={indicator.options as any} />
+                  )}
+                </Pane>
+              )
+            })}
 
             <TimeScale
               onVisibleLogicalRangeChange={onVisibleRangeChange}
             >
-              <TimeScaleFitContentTrigger deps={[chartData.length > 0 ? chartData[0].date : 0, activeTags.length, showVolume, chartType]} />
+              {/* Re-fit only on a deliberate change of what is charted. Keying
+                  this on the data itself would refit after a zoom refetch and
+                  throw away the zoom the user just made. */}
+              <TimeScaleFitContentTrigger deps={[fitKey]} />
             </TimeScale>
           </Chart>
         ) : (
@@ -602,7 +807,50 @@ export function DynamicStockChart({
             {!loadingData && "No data available"}
           </div>
         )}
+
+        {/* One label per pane, positioned over the pane it names. Pane 0 is the
+            price chart and is never collapsible, so the labels below start at
+            the second measured pane. */}
+        {chartData.length > 0 && visiblePanes.map((pane, index) => {
+          const position = paneLayout[index + 1]
+          if (!position) return null
+
+          return (
+            <button
+              key={pane.id}
+              type="button"
+              onClick={() => togglePane(pane.id)}
+              style={{ top: position.top + 2 }}
+              className="absolute left-2 z-20 flex items-center gap-1 rounded bg-background/75 px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground backdrop-blur-sm transition-colors hover:text-foreground"
+              title={`Collapse ${pane.label}`}
+            >
+              <ChevronDown className="h-3 w-3" />
+              {pane.label}
+            </button>
+          )
+        })}
       </div>
+
+      {/* Folded-away panes, kept visible so they can be brought back. */}
+      {collapsedPanes.size > 0 && (
+        <div className="flex flex-wrap items-center gap-2 px-1">
+          <span className="text-xs text-muted-foreground">Hidden:</span>
+          {bottomPanes
+            .filter(pane => collapsedPanes.has(pane.id))
+            .map(pane => (
+              <button
+                key={pane.id}
+                type="button"
+                onClick={() => togglePane(pane.id)}
+                className="flex items-center gap-1 rounded border border-border px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+                title={`Show ${pane.label}`}
+              >
+                <ChevronRight className="h-3 w-3" />
+                {pane.label}
+              </button>
+            ))}
+        </div>
+      )}
 
       {/* Top Row: Tag Input + Basic Controls */}
       <div className="flex flex-col md:flex-row gap-4 justify-between">

--- a/apps/ai-broker-web/components/investing/shared/quote-view.tsx
+++ b/apps/ai-broker-web/components/investing/shared/quote-view.tsx
@@ -19,6 +19,7 @@ import { ArrowLeft, Loader2, TrendingUp, TrendingDown, DollarSign, Activity, Bar
 import Link from "next/link"
 import { useSession } from "@/lib/auth/client"
 import { DynamicStockChart } from "@/components/investing/charts/dynamic-stock-chart"
+import { useDebouncedSymbol } from "@/lib/stocks/use-debounced-symbol"
 import { TradeModal } from "@/components/investing/trading/trade-modal"
 
 // Helper function to get stock logo URLs
@@ -144,7 +145,11 @@ function ExternalLinkItem({ link, symbol }: { link: ExternalLink; symbol: string
   )
 }
 
-export function QuoteView({ symbol, showBackButton = true, tradeSignals = [] }: QuoteViewProps) {
+export function QuoteView({ symbol: inputSymbol, showBackButton = true, tradeSignals = [] }: QuoteViewProps) {
+  // The parent feeds this straight from a search box, so it changes on every
+  // keystroke. Settle it before fetching: otherwise typing "GOOGL" sends a
+  // quote plus three historical requests for each of GOO, GOOG and GOOGL.
+  const symbol = useDebouncedSymbol(inputSymbol)
   const router = useRouter()
   const { data: session } = useSession()
   const [data, setData] = useState<QuoteData | null>(null)
@@ -289,31 +294,44 @@ export function QuoteView({ symbol, showBackButton = true, tradeSignals = [] }: 
   }, [symbol, session])
 
   useEffect(() => {
-    if (!symbol) return
+    if (!symbol) {
+      setLoading(false)
+      return
+    }
+
+    // Abort the previous symbol's request when the symbol changes again, so a
+    // slow response for an earlier ticker cannot overwrite the current one.
+    const controller = new AbortController()
 
     const fetchQuote = async () => {
       try {
         setLoading(true)
         setError("") // Clear any previous errors
 
-        const res = await fetch(`/api/stocks/quote/${symbol}`)
+        const res = await fetch(`/api/stocks/quote/${encodeURIComponent(symbol)}`, {
+          signal: controller.signal,
+        })
         const json = await res.json()
+        if (controller.signal.aborted) return
 
         if (json.success && json.data) {
           setData(json.data)
           setError("") // Clear error on success
         } else {
+          setData(null)
           setError(json.error || "Failed to fetch quote data")
         }
       } catch (err) {
+        if ((err as Error)?.name === "AbortError") return
         console.error(err)
         setError("An error occurred while fetching data")
       } finally {
-        setLoading(false)
+        if (!controller.signal.aborted) setLoading(false)
       }
     }
 
     fetchQuote()
+    return () => controller.abort()
   }, [symbol])
 
 
@@ -342,23 +360,30 @@ export function QuoteView({ symbol, showBackButton = true, tradeSignals = [] }: 
   useEffect(() => {
     if (!symbol) return
 
+    const controller = new AbortController()
+
     const fetchPerformanceData = async () => {
       try {
-        // Try to fetch 5 years of data first
-        let res = await fetch(`/api/stocks/historical/${symbol}?range=5y&interval=1d`)
-        let json = await res.json()
+        const hasRows = (payload: any) =>
+          payload?.success && Array.isArray(payload.data) && payload.data.length > 0
 
-        // If 5y fails, try 2y as fallback
-        if (!json.success || !json.data || !Array.isArray(json.data) || json.data.length === 0) {
-          res = await fetch(`/api/stocks/historical/${symbol}?range=2y&interval=1d`)
-          json = await res.json()
+        const fetchRange = async (range: string) => {
+          const res = await fetch(
+            `/api/stocks/historical/${encodeURIComponent(symbol)}?range=${range}&interval=1d`,
+            { signal: controller.signal },
+          )
+          return res.json()
         }
 
-        // If 2y fails, try 1y as final fallback
-        if (!json.success || !json.data || !Array.isArray(json.data) || json.data.length === 0) {
-          res = await fetch(`/api/stocks/historical/${symbol}?range=1y&interval=1d`)
-          json = await res.json()
+        // Shorter ranges are a fallback for symbols whose history does not go
+        // back five years. A 400/404 means the symbol itself is no good, so
+        // stop there rather than asking twice more for the same missing stock.
+        let json = await fetchRange("5y")
+        for (const range of ["2y", "1y"]) {
+          if (hasRows(json) || json?.code === "INVALID_SYMBOL" || json?.code === "SYMBOL_NOT_FOUND") break
+          json = await fetchRange(range)
         }
+        if (controller.signal.aborted) return
 
         if (json.success && json.data && Array.isArray(json.data)) {
           const history = json.data
@@ -405,12 +430,14 @@ export function QuoteView({ symbol, showBackButton = true, tradeSignals = [] }: 
           })
         }
       } catch (err) {
+        if ((err as Error)?.name === "AbortError") return
         // Silently handle errors - performance metrics are non-critical
         console.error("Performance data fetch error:", err)
       }
     }
 
     fetchPerformanceData()
+    return () => controller.abort()
   }, [symbol])
 
   const toggleWatchlist = async () => {

--- a/apps/ai-broker-web/components/landing/agents-team-section.tsx
+++ b/apps/ai-broker-web/components/landing/agents-team-section.tsx
@@ -7,8 +7,6 @@ import {
   TrendingUp,
 } from "lucide-react"
 
-import { VideoLightbox } from "@/components/landing/video-lightbox"
-
 const agents = [
   {
     icon: BarChart3,
@@ -52,7 +50,7 @@ export function AgentsTeamSection() {
   return (
     <section id="agents" className="relative border-t border-border py-24 lg:py-32">
       <div className="mx-auto max-w-7xl px-5 lg:px-8">
-        <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr_auto] lg:items-end">
+        <div className="grid gap-10 lg:grid-cols-[1fr_1.2fr] lg:items-end">
           <div>
             <div className="text-xs font-medium uppercase tracking-[0.2em] text-primary">
               The Team
@@ -67,12 +65,6 @@ export function AgentsTeamSection() {
             Every trade is the output of a specialist chain — analyst, researcher, trader, risk,
             portfolio manager. No single black box. You see who said what, and why.
           </p>
-          <VideoLightbox
-            videoId="N5cHK6K50Ds"
-            title="How the agent team builds one thesis"
-            caption="See the agents at work"
-            className="w-full max-w-xs lg:w-64"
-          />
         </div>
 
         <div className="mt-14 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/ai-broker-web/components/landing/video-showcase-section.tsx
+++ b/apps/ai-broker-web/components/landing/video-showcase-section.tsx
@@ -1,0 +1,37 @@
+import { VideoLightbox } from "@/components/landing/video-lightbox"
+
+/**
+ * Standalone section for the agent-team walkthrough video.
+ *
+ * The video used to sit as a thumbnail in the corner of the agents section
+ * header, small enough to read as a footnote. It carries the clearest
+ * explanation of how the agents work together, so it gets its own titled
+ * section at a size worth clicking.
+ */
+export function VideoShowcaseSection() {
+  return (
+    <section id="walkthrough" className="relative border-t border-border py-24 lg:py-32">
+      <div className="mx-auto max-w-5xl px-5 lg:px-8">
+        <div className="text-center">
+          <div className="text-xs font-medium uppercase tracking-[0.2em] text-primary">
+            Watch
+          </div>
+          <h2 className="font-display mt-3 text-4xl tracking-tight lg:text-5xl">
+            See the agents work
+          </h2>
+          <p className="mx-auto mt-4 max-w-2xl text-lg text-muted-foreground">
+            A walkthrough of one full cycle — the analysts gathering evidence, the bull and bear
+            debate, and the risk agent sizing the position that comes out of it.
+          </p>
+        </div>
+
+        <VideoLightbox
+          videoId="N5cHK6K50Ds"
+          title="How the agent team builds one thesis"
+          caption="How the agent team builds one thesis"
+          className="mt-10 w-full"
+        />
+      </div>
+    </section>
+  )
+}

--- a/apps/ai-broker-web/lib/stocks/__tests__/quote-cache-service.test.ts
+++ b/apps/ai-broker-web/lib/stocks/__tests__/quote-cache-service.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Tests for the quote cache.
+ *
+ * Two defects live here. `getCachedQuote` took a TTL from every caller and
+ * ignored it, so a cached price was served forever; and cached historical rows
+ * came back in whatever order the database produced, while callers read the
+ * first and last elements as the period bounds and charted the series in order.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const fakeDb = vi.hoisted(() => ({
+  selectRows: [] as unknown[],
+  insertCalls: [] as unknown[],
+  conflictCalls: [] as unknown[],
+}))
+
+vi.mock('@/packages/investing/src/db', () => {
+  const chain = (rows: () => unknown[]) => {
+    const node: Record<string, unknown> = {}
+    for (const m of ['from', 'where', 'limit', 'orderBy', 'values', 'set']) {
+      node[m] = (...args: unknown[]) => {
+        if (m === 'values') fakeDb.insertCalls.push(args[0])
+        return node
+      }
+    }
+    node.onConflictDoUpdate = (arg: unknown) => {
+      fakeDb.conflictCalls.push(arg)
+      return node
+    }
+    node.onConflictDoNothing = () => node
+    node.then = (res: (v: unknown) => unknown, rej?: (e: unknown) => unknown) =>
+      Promise.resolve(rows()).then(res, rej)
+    return node
+  }
+  return {
+    db: {
+      select: () => chain(() => fakeDb.selectRows),
+      insert: () => chain(() => []),
+      update: () => chain(() => []),
+      delete: () => chain(() => []),
+    },
+  }
+})
+
+import { QuoteCacheService, QUOTE_CACHE_TTL } from '@/packages/investing/src/stocks/quote-cache-service'
+
+const service = new QuoteCacheService()
+
+/** A cache row as stored, `updatedAt` written `ageMs` ago. */
+const row = (ageMs: number | null) => ({
+  symbol: 'AAPL',
+  price: 190.5,
+  change: 1.5,
+  changePercent: 0.8,
+  open: 189,
+  high: 191,
+  low: 188.5,
+  previousClose: 189,
+  volume: 1_000_000,
+  updatedAt: ageMs === null ? null : new Date(Date.now() - ageMs),
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fakeDb.selectRows = []
+  fakeDb.insertCalls = []
+  fakeDb.conflictCalls = []
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('getCachedQuote — freshness', () => {
+  it('returns a quote written moments ago', async () => {
+    fakeDb.selectRows = [row(1_000)]
+
+    await expect(service.getCachedQuote('AAPL')).resolves.toMatchObject({
+      symbol: 'AAPL',
+      price: 190.5,
+    })
+  })
+
+  it('treats a row older than the default TTL as a miss', async () => {
+    fakeDb.selectRows = [row(QUOTE_CACHE_TTL + 1_000)]
+
+    await expect(service.getCachedQuote('AAPL')).resolves.toBeNull()
+  })
+
+  it('honors an explicit TTL from the caller', async () => {
+    fakeDb.selectRows = [row(30_000)]
+
+    // Fresh under a five-minute window, stale under a ten-second one.
+    await expect(service.getCachedQuote('AAPL', 300_000)).resolves.not.toBeNull()
+    await expect(service.getCachedQuote('AAPL', 10_000)).resolves.toBeNull()
+  })
+
+  it('treats a row with no timestamp as stale', async () => {
+    // Rows written before the column existed read back as null; serving them
+    // would be serving a price of unknown age.
+    fakeDb.selectRows = [row(null)]
+
+    await expect(service.getCachedQuote('AAPL')).resolves.toBeNull()
+  })
+
+  it('accepts a row of any age when the TTL is Infinity', async () => {
+    fakeDb.selectRows = [row(365 * 24 * 60 * 60 * 1000)]
+
+    await expect(service.getCachedQuote('AAPL', Infinity)).resolves.not.toBeNull()
+  })
+
+  it('returns null when nothing is cached', async () => {
+    fakeDb.selectRows = []
+
+    await expect(service.getCachedQuote('AAPL')).resolves.toBeNull()
+  })
+})
+
+describe('saveQuoteToCache', () => {
+  const quote = {
+    symbol: 'aapl',
+    price: 190.567,
+    change: 1.234,
+    changePercent: 0.789,
+    open: 189.111,
+    high: 191.999,
+    low: 188.5,
+    previousClose: 189,
+    volume: 1_000_000,
+    marketCap: 3e12,
+    currency: 'USD',
+    name: 'Apple Inc.',
+    exchange: 'NASDAQ',
+    timestamp: new Date(),
+    source: 'yfinance' as const,
+  }
+
+  it('upper-cases the symbol so reads and writes share a key', async () => {
+    await service.saveQuoteToCache(quote)
+
+    expect(fakeDb.insertCalls[0]).toMatchObject({ symbol: 'AAPL' })
+  })
+
+  it('rounds prices to two decimals', async () => {
+    await service.saveQuoteToCache(quote)
+
+    expect(fakeDb.insertCalls[0]).toMatchObject({
+      price: 190.57,
+      change: 1.23,
+      open: 189.11,
+      high: 192,
+    })
+  })
+
+  it('stamps updatedAt so the row can later be aged out', async () => {
+    await service.saveQuoteToCache(quote)
+
+    expect((fakeDb.insertCalls[0] as any).updatedAt).toBeInstanceOf(Date)
+  })
+
+  it('refreshes updatedAt on conflict rather than leaving the old timestamp', async () => {
+    await service.saveQuoteToCache(quote)
+
+    expect((fakeDb.conflictCalls[0] as any).set.updatedAt).toBeInstanceOf(Date)
+  })
+})
+
+describe('getCachedHistoricalQuotes', () => {
+  const unordered = [
+    { date: '2026-03-02', open: 3, high: 3, low: 3, close: 3, volume: 3, adjustedClose: null },
+    { date: '2026-01-02', open: 1, high: 1, low: 1, close: 1, volume: 1, adjustedClose: null },
+    { date: '2026-02-02', open: 2, high: 2, low: 2, close: 2, volume: 2, adjustedClose: null },
+  ]
+
+  it('returns rows oldest-first regardless of database order', async () => {
+    fakeDb.selectRows = unordered
+
+    const result = await service.getCachedHistoricalQuotes('AAPL')
+
+    expect(result.map((r) => r.date)).toEqual(['2026-01-02', '2026-02-02', '2026-03-02'])
+  })
+
+  it('puts the true period bounds at the ends, which callers read directly', async () => {
+    fakeDb.selectRows = unordered
+
+    const result = await service.getCachedHistoricalQuotes('AAPL')
+
+    expect(result[0].date).toBe('2026-01-02')
+    expect(result[result.length - 1].date).toBe('2026-03-02')
+  })
+
+  it('filters to the requested window, inclusive of both bounds', async () => {
+    fakeDb.selectRows = unordered
+
+    const result = await service.getCachedHistoricalQuotes('AAPL', '2026-01-02', '2026-02-02')
+
+    expect(result.map((r) => r.date)).toEqual(['2026-01-02', '2026-02-02'])
+  })
+
+  it('returns an empty array when nothing falls in the window', async () => {
+    fakeDb.selectRows = unordered
+
+    await expect(
+      service.getCachedHistoricalQuotes('AAPL', '2027-01-01', '2027-12-31'),
+    ).resolves.toEqual([])
+  })
+})

--- a/apps/ai-broker-web/lib/stocks/__tests__/symbol.test.ts
+++ b/apps/ai-broker-web/lib/stocks/__tests__/symbol.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Tests for the shared ticker validation the stock routes use to
+ * separate "not a ticker" (400) from "no such ticker" (404) before any upstream
+ * provider is called.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  isKnownSymbol,
+  isValidSymbolFormat,
+  normalizeSymbol,
+  validateSymbol,
+} from '../symbol'
+
+describe('normalizeSymbol', () => {
+  it('upper-cases and trims', () => {
+    expect(normalizeSymbol('  aapl ')).toBe('AAPL')
+  })
+
+  it('decodes a percent-encoded path segment', () => {
+    expect(normalizeSymbol('BRK%2EB')).toBe('BRK.B')
+  })
+
+  it('returns an empty string for a malformed escape rather than throwing', () => {
+    expect(normalizeSymbol('%E0%A4%A')).toBe('%E0%A4%A')
+  })
+
+  it.each([null, undefined, 42, {}])('returns an empty string for %s', (input) => {
+    expect(normalizeSymbol(input as any)).toBe('')
+  })
+})
+
+describe('isValidSymbolFormat', () => {
+  it.each(['A', 'AAPL', 'GOOGL', 'BRK.B', 'RDS-A', 'BF/B'])('accepts %s', (symbol) => {
+    expect(isValidSymbolFormat(symbol)).toBe(true)
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['GOOGLE', 'six letters is past the ticker limit'],
+    ['AA PL', 'contains a space'],
+    ['AAPL;DROP', 'contains punctuation'],
+    ['123', 'digits only'],
+    ['aapl', 'not upper-cased — callers normalize first'],
+    ['A'.repeat(40), 'absurdly long'],
+  ])('rejects %s (%s)', (symbol) => {
+    expect(isValidSymbolFormat(symbol)).toBe(false)
+  })
+})
+
+describe('isKnownSymbol', () => {
+  it('finds a ticker present in the bundled dataset', () => {
+    expect(isKnownSymbol('AAPL')).toBe(true)
+    expect(isKnownSymbol('GOOGL')).toBe(true)
+  })
+
+  it('rejects a ticker-shaped string that is not listed', () => {
+    expect(isKnownSymbol('ZZZZZ')).toBe(false)
+  })
+})
+
+describe('validateSymbol', () => {
+  it('accepts a real ticker and returns it normalized', () => {
+    expect(validateSymbol('aapl')).toEqual({ ok: true, symbol: 'AAPL' })
+  })
+
+  it('returns 400 MISSING_SYMBOL for an empty segment', () => {
+    const result = validateSymbol('')
+    expect(result).toMatchObject({ ok: false, status: 400, code: 'MISSING_SYMBOL' })
+  })
+
+  it('returns 400 INVALID_SYMBOL for something not shaped like a ticker', () => {
+    const result = validateSymbol('GOOGLE')
+    expect(result).toMatchObject({ ok: false, status: 400, code: 'INVALID_SYMBOL' })
+  })
+
+  it('returns 404 SYMBOL_NOT_FOUND for a ticker-shaped string with no listing', () => {
+    const result = validateSymbol('ZZZZZ')
+    expect(result).toMatchObject({ ok: false, status: 404, code: 'SYMBOL_NOT_FOUND' })
+  })
+
+  it.each(['GOO', 'GOOH', 'GOOHL'])(
+    'rejects the partial ticker %s a search box sends mid-typing',
+    (partial) => {
+      expect(validateSymbol(partial).ok).toBe(false)
+    },
+  )
+
+  it('skips the listing check when requireKnown is false', () => {
+    expect(validateSymbol('ZZZZZ', { requireKnown: false })).toEqual({
+      ok: true,
+      symbol: 'ZZZZZ',
+    })
+  })
+
+  it('still enforces the format when requireKnown is false', () => {
+    expect(validateSymbol('NOT A SYMBOL', { requireKnown: false }).ok).toBe(false)
+  })
+})

--- a/apps/ai-broker-web/lib/stocks/__tests__/unified-quote-service.test.ts
+++ b/apps/ai-broker-web/lib/stocks/__tests__/unified-quote-service.test.ts
@@ -1,0 +1,215 @@
+/**
+ * @fileoverview Tests for the unified quote service's provider fallback.
+ *
+ * Two defects are pinned here: a symbol that was not normalized, so "goog"
+ * missed the cache entry "GOOG" had written and refetched every time; and an
+ * Alpaca response with no ask or bid, which was accepted as a successful quote
+ * priced at $0 and then cached for everyone else to read.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getCachedQuote: vi.fn(),
+  saveQuoteToCache: vi.fn(),
+  alpacaGetQuote: vi.fn(),
+  yahooGetQuote: vi.fn(),
+}))
+
+vi.mock('@/packages/investing/src/stocks/quote-cache-service', () => ({
+  quoteCacheService: {
+    getCachedQuote: mocks.getCachedQuote,
+    saveQuoteToCache: mocks.saveQuoteToCache,
+    saveQuotesToCache: vi.fn(),
+    getCachedHistoricalQuotes: vi.fn().mockResolvedValue([]),
+    saveHistoricalQuotes: vi.fn(),
+  },
+}))
+vi.mock('@/packages/investing/src/alpaca/alpaca-mcp-client', () => ({
+  getAlpacaMCPClient: () => ({ getQuote: mocks.alpacaGetQuote }),
+}))
+vi.mock('@/packages/investing/src/stocks/yahoo-finance-wrapper', () => ({
+  yahooFinanceWrapper: { getQuote: mocks.yahooGetQuote, getHistorical: vi.fn() },
+}))
+vi.mock('@/packages/investing/src/stocks/finnhub-wrapper', () => ({
+  finnhub: { getQuote: vi.fn(), getHistoricalData: vi.fn() },
+  FinnhubWrapper: class {},
+}))
+
+import { getQuote } from '@/packages/investing/src/stocks/unified-quote-service'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getCachedQuote.mockResolvedValue(null)
+  mocks.saveQuoteToCache.mockResolvedValue(undefined)
+  mocks.alpacaGetQuote.mockResolvedValue(null)
+  mocks.yahooGetQuote.mockResolvedValue({ success: false })
+})
+
+describe('getQuote — symbol handling', () => {
+  it('rejects an empty symbol without calling a provider', async () => {
+    const result = await getQuote('')
+
+    expect(result.success).toBe(false)
+    expect(mocks.alpacaGetQuote).not.toHaveBeenCalled()
+    expect(mocks.yahooGetQuote).not.toHaveBeenCalled()
+  })
+
+  it('rejects a whitespace-only symbol', async () => {
+    await expect(getQuote('   ')).resolves.toMatchObject({ success: false })
+  })
+
+  it('upper-cases the symbol before reading the cache', async () => {
+    // The cache keys on the upper-cased symbol; without this, "goog" never
+    // saw the entry "GOOG" wrote and refetched on every call.
+    await getQuote('goog')
+
+    expect(mocks.getCachedQuote).toHaveBeenCalledWith('GOOG', undefined)
+  })
+
+  it('reports the normalized symbol on the returned quote', async () => {
+    mocks.alpacaGetQuote.mockResolvedValue({ ap: 100, t: '2026-09-11T20:00:00Z' })
+
+    const result = await getQuote(' aapl ')
+
+    expect(result.data?.symbol).toBe('AAPL')
+  })
+})
+
+describe('getQuote — cache', () => {
+  it('returns a cached quote without calling a provider', async () => {
+    mocks.getCachedQuote.mockResolvedValue({ symbol: 'AAPL', price: 190 })
+
+    const result = await getQuote('AAPL')
+
+    expect(result).toMatchObject({ success: true, data: { price: 190 } })
+    expect(mocks.alpacaGetQuote).not.toHaveBeenCalled()
+  })
+
+  it('skips the cache when useCache is false', async () => {
+    mocks.getCachedQuote.mockResolvedValue({ symbol: 'AAPL', price: 190 })
+    mocks.alpacaGetQuote.mockResolvedValue({ ap: 200 })
+
+    const result = await getQuote('AAPL', { useCache: false })
+
+    expect(mocks.getCachedQuote).not.toHaveBeenCalled()
+    expect(result.data?.price).toBe(200)
+  })
+
+  it('passes the caller TTL through to the cache', async () => {
+    await getQuote('AAPL', { cacheTTL: 300_000 })
+
+    expect(mocks.getCachedQuote).toHaveBeenCalledWith('AAPL', 300_000)
+  })
+
+  it('falls through to a provider when the cache read throws', async () => {
+    mocks.getCachedQuote.mockRejectedValue(new Error('D1 unavailable'))
+    mocks.alpacaGetQuote.mockResolvedValue({ ap: 150 })
+
+    await expect(getQuote('AAPL')).resolves.toMatchObject({ success: true })
+  })
+})
+
+describe('getQuote — provider fallback', () => {
+  it('prefers Alpaca and caches what it returns', async () => {
+    mocks.alpacaGetQuote.mockResolvedValue({ ap: 190.5, x: 'NASDAQ' })
+
+    const result = await getQuote('AAPL')
+
+    expect(result.data).toMatchObject({ price: 190.5, source: 'alpaca' })
+    expect(mocks.saveQuoteToCache).toHaveBeenCalled()
+    expect(mocks.yahooGetQuote).not.toHaveBeenCalled()
+  })
+
+  it('uses the bid when there is no ask', async () => {
+    mocks.alpacaGetQuote.mockResolvedValue({ bp: 188.25 })
+
+    await expect(getQuote('AAPL')).resolves.toMatchObject({ data: { price: 188.25 } })
+  })
+
+  it.each([
+    ['zero ask and bid', { ap: 0, bp: 0 }],
+    ['no price fields at all', { x: 'NASDAQ' }],
+    ['a non-numeric ask', { ap: 'N/A' }],
+  ])('does not accept an Alpaca response with %s', async (_label, payload) => {
+    // A $0 price used to be reported as a successful quote and written to the
+    // cache, so every later reader saw a real stock priced at zero.
+    mocks.alpacaGetQuote.mockResolvedValue(payload)
+    mocks.yahooGetQuote.mockResolvedValue({
+      success: true,
+      data: { regularMarketPrice: 190, longName: 'Apple Inc.' },
+    })
+
+    const result = await getQuote('AAPL')
+
+    expect(result.data?.source).toBe('yfinance')
+    expect(result.data?.price).toBe(190)
+  })
+
+  it('falls back to Yahoo when Alpaca throws', async () => {
+    mocks.alpacaGetQuote.mockRejectedValue(new Error('alpaca down'))
+    mocks.yahooGetQuote.mockResolvedValue({
+      success: true,
+      data: { regularMarketPrice: 190, currency: 'USD' },
+    })
+
+    await expect(getQuote('AAPL')).resolves.toMatchObject({
+      success: true,
+      data: { price: 190, source: 'yfinance' },
+    })
+  })
+
+  it('maps the Yahoo payload onto the normalized shape', async () => {
+    mocks.alpacaGetQuote.mockResolvedValue(null)
+    mocks.yahooGetQuote.mockResolvedValue({
+      success: true,
+      data: {
+        regularMarketPrice: 190,
+        regularMarketChange: 2,
+        regularMarketChangePercent: 1.05,
+        regularMarketOpen: 188,
+        regularMarketDayHigh: 191,
+        regularMarketDayLow: 187,
+        regularMarketPreviousClose: 188,
+        volume: 50_000,
+        marketCap: 3e12,
+        currency: 'USD',
+        longName: 'Apple Inc.',
+        exchange: 'NASDAQ',
+      },
+    })
+
+    const result = await getQuote('AAPL')
+
+    expect(result.data).toMatchObject({
+      price: 190,
+      change: 2,
+      changePercent: 1.05,
+      open: 188,
+      high: 191,
+      low: 187,
+      previousClose: 188,
+      volume: 50_000,
+      marketCap: 3e12,
+      currency: 'USD',
+      name: 'Apple Inc.',
+      exchange: 'NASDAQ',
+    })
+  })
+
+  it('does not accept a Yahoo payload priced at zero', async () => {
+    mocks.yahooGetQuote.mockResolvedValue({
+      success: true,
+      data: { regularMarketPrice: 0, longName: 'Delisted Co.' },
+    })
+
+    await expect(getQuote('AAPL')).resolves.toMatchObject({ success: false })
+  })
+
+  it('reports failure when every provider comes up empty', async () => {
+    const result = await getQuote('AAPL')
+
+    expect(result.success).toBe(false)
+    expect(result.error).toMatch(/AAPL/)
+    expect(mocks.saveQuoteToCache).not.toHaveBeenCalled()
+  })
+})

--- a/apps/ai-broker-web/lib/stocks/symbol.ts
+++ b/apps/ai-broker-web/lib/stocks/symbol.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Ticker symbol validation shared by the stock API routes.
+ *
+ * The symbol arrives as a URL path segment typed by a user, so it is entirely
+ * untrusted: search boxes send partial tickers while someone is still typing
+ * ("GOO", "GOOH", "GOOHL" on the way to "GOOGL"), and every one of those used
+ * to reach the upstream data providers. Validating here turns those into a
+ * cheap local 400/404 instead of a provider round-trip, and — just as
+ * importantly — keeps an unknown ticker from being reported as a 500, which
+ * reads as "our server is broken" when it means "no such stock".
+ */
+import stockNamesData from '@/packages/investing/src/stock-names-data/stock-names.json'
+
+/** `[symbol, name, industryId, marketCap, flags]` as stored in stock-names.json. */
+type StockNameEntry = [string, string, number, number, number]
+
+/**
+ * Tickers are 1-5 letters, optionally with a class/exchange suffix such as
+ * `BRK.B`, `RDS-A`, or `BF/B`. Anything longer or carrying other characters is
+ * not a ticker anyone can look up.
+ */
+const SYMBOL_PATTERN = /^[A-Z]{1,5}(?:[.\-/][A-Z]{1,4})?$/
+
+/** Longest string worth pattern-matching; guards against absurd path segments. */
+const MAX_SYMBOL_LENGTH = 12
+
+let knownSymbols: Set<string> | null = null
+
+/**
+ * The set of tickers present in the bundled stock-names dataset, built once on
+ * first use. The dataset has tens of thousands of rows, so a `Set` keeps the
+ * per-request check O(1) rather than scanning the array each time.
+ */
+function getKnownSymbols(): Set<string> {
+  if (knownSymbols === null) {
+    knownSymbols = new Set(
+      (stockNamesData as StockNameEntry[]).map((entry) => entry[0]),
+    )
+  }
+  return knownSymbols
+}
+
+/** Trim, strip a URL encoding, and upper-case. Returns `''` for junk input. */
+export function normalizeSymbol(raw: string | null | undefined): string {
+  if (typeof raw !== 'string') return ''
+  let value = raw.trim()
+  if (value.includes('%')) {
+    try {
+      value = decodeURIComponent(value)
+    } catch {
+      // A malformed escape sequence is not a symbol; fall through and let the
+      // pattern check below reject the raw value.
+    }
+  }
+  return value.trim().toUpperCase()
+}
+
+/** True when `symbol` is shaped like a ticker, regardless of whether it exists. */
+export function isValidSymbolFormat(symbol: string): boolean {
+  return symbol.length > 0 && symbol.length <= MAX_SYMBOL_LENGTH && SYMBOL_PATTERN.test(symbol)
+}
+
+/** True when `symbol` appears in the bundled ticker dataset. */
+export function isKnownSymbol(symbol: string): boolean {
+  return getKnownSymbols().has(symbol)
+}
+
+/** Outcome of {@link validateSymbol}: the normalized symbol, or why it failed. */
+export type SymbolValidation =
+  | { ok: true; symbol: string }
+  | { ok: false; symbol: string; status: 400 | 404; error: string; code: string }
+
+/**
+ * Normalize and check a symbol from a request.
+ *
+ * @param raw - The raw path segment or query value.
+ * @param options.requireKnown - Also require the ticker to exist in the bundled
+ *   dataset. The dataset covers US listings only, so routes that legitimately
+ *   serve other venues (forex, crypto, foreign listings) pass `false` and get
+ *   format checking alone.
+ */
+export function validateSymbol(
+  raw: string | null | undefined,
+  options: { requireKnown?: boolean } = {},
+): SymbolValidation {
+  const { requireKnown = true } = options
+  const symbol = normalizeSymbol(raw)
+
+  if (!symbol) {
+    return {
+      ok: false,
+      symbol,
+      status: 400,
+      error: 'A stock symbol is required',
+      code: 'MISSING_SYMBOL',
+    }
+  }
+
+  if (!isValidSymbolFormat(symbol)) {
+    return {
+      ok: false,
+      symbol,
+      status: 400,
+      error: `"${symbol}" is not a valid stock symbol`,
+      code: 'INVALID_SYMBOL',
+    }
+  }
+
+  if (requireKnown && !isKnownSymbol(symbol)) {
+    return {
+      ok: false,
+      symbol,
+      status: 404,
+      error: `Unknown stock symbol: ${symbol}`,
+      code: 'SYMBOL_NOT_FOUND',
+    }
+  }
+
+  return { ok: true, symbol }
+}

--- a/apps/ai-broker-web/lib/stocks/use-debounced-symbol.ts
+++ b/apps/ai-broker-web/lib/stocks/use-debounced-symbol.ts
@@ -1,0 +1,42 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { isValidSymbolFormat, normalizeSymbol } from "@/lib/stocks/symbol"
+
+/** How long the symbol must hold still before it is worth a network request. */
+const DEFAULT_DELAY_MS = 350
+
+/**
+ * Settle a symbol that changes as someone types before anything fetches on it.
+ *
+ * Search inputs push a new symbol on every keystroke, and the panels below them
+ * fetch per symbol. Typing "GOOGL" therefore fired a quote and up to three
+ * historical requests for each of G, GO, GOO, GOOG and GOOGL — a burst of
+ * requests for tickers the user never meant to look up, whose responses could
+ * also land out of order and leave the wrong stock on screen.
+ *
+ * This returns the symbol only once it has stopped changing and looks like a
+ * ticker, so callers fetch once for what was actually typed.
+ *
+ * @param symbol - The live, per-keystroke symbol.
+ * @param delayMs - Quiet period required before the symbol is released.
+ * @returns The settled upper-cased symbol, or `''` while it is still in flux or
+ *   is not ticker-shaped.
+ */
+export function useDebouncedSymbol(symbol: string, delayMs: number = DEFAULT_DELAY_MS): string {
+  const normalized = normalizeSymbol(symbol)
+  const usable = isValidSymbolFormat(normalized) ? normalized : ""
+
+  // Seed with the first value so an already-settled symbol (a page opened
+  // directly on /stocks/AAPL) renders without waiting out the delay.
+  const [settled, setSettled] = useState(usable)
+
+  useEffect(() => {
+    if (usable === settled) return
+
+    const timer = setTimeout(() => setSettled(usable), delayMs)
+    return () => clearTimeout(timer)
+  }, [usable, settled, delayMs])
+
+  return settled
+}

--- a/apps/ai-broker-web/lib/ui-config.tsx
+++ b/apps/ai-broker-web/lib/ui-config.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react"
 import { createContext, useContext, useState, useEffect, useCallback } from "react"
+import { useSession } from "@/lib/auth/client"
 
 export interface TickerConfig {
   showIcon: boolean
@@ -52,12 +53,26 @@ export function UIConfigProvider({ children }: { children: React.ReactNode }) {
   const [config, setConfig] = useState<UIConfig>(defaultUIConfig)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const { data: session, isPending: sessionPending } = useSession()
 
-  // Fetch config on mount
+  // Fetch the saved config once we know who is asking. Settings are per-user,
+  // so requesting them while signed out can only 401 — every anonymous page
+  // load used to spend a request to be told that. Signed-out visitors keep the
+  // defaults below.
   useEffect(() => {
+    if (sessionPending) return
+
+    if (!session?.user) {
+      setConfig(defaultUIConfig)
+      setLoading(false)
+      return
+    }
+
+    const controller = new AbortController()
+
     const fetchConfig = async () => {
       try {
-        const response = await fetch("/api/user/settings")
+        const response = await fetch("/api/user/settings", { signal: controller.signal })
         if (response.ok) {
           const data = await response.json()
           if (data.uiConfig) {
@@ -75,14 +90,16 @@ export function UIConfigProvider({ children }: { children: React.ReactNode }) {
           }
         }
       } catch (error) {
+        if ((error as Error)?.name === "AbortError") return
         console.error("Failed to fetch UI config:", error)
       } finally {
-        setLoading(false)
+        if (!controller.signal.aborted) setLoading(false)
       }
     }
 
     fetchConfig()
-  }, [])
+    return () => controller.abort()
+  }, [session?.user?.id, sessionPending])
 
   const updateConfig = useCallback((newConfig: Partial<UIConfig>) => {
     setConfig((prev) => ({

--- a/apps/ai-broker-web/migrations/0018_quote_cache_updated_at.sql
+++ b/apps/ai-broker-web/migrations/0018_quote_cache_updated_at.sql
@@ -1,0 +1,7 @@
+-- Restore an age column on the quote cache.
+--
+-- `stock_quote_cache` rows carried no timestamp, so `getCachedQuote` had no way
+-- to apply the `cacheTTL` its callers pass and every cached quote was served
+-- indefinitely. Existing rows get NULL, which the service treats as expired, so
+-- each symbol is refetched once and then cached with a real timestamp.
+ALTER TABLE `stock_quote_cache` ADD `updated_at` integer;

--- a/apps/ai-broker-web/migrations/meta/_journal.json
+++ b/apps/ai-broker-web/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1787647566930,
       "tag": "0017_greedy_jackal",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1787647567930,
+      "tag": "0018_quote_cache_updated_at",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/ai-broker-web/vitest.config.ts
+++ b/apps/ai-broker-web/vitest.config.ts
@@ -30,6 +30,11 @@ export default defineConfig({
     alias: [
       { find: /^@\/packages\//, replacement: `${resolve(rootDir, '../../packages')}/` },
       { find: /^@\//, replacement: `${resolve(rootDir, '.')}/` },
+      // The workspace packages publish from `dist/`, which only exists after a
+      // build. Point their subpath exports at the TypeScript sources so route
+      // tests run against the same code the app imports without a build step.
+      { find: /^investing\/(.*)$/, replacement: `${resolve(rootDir, '../../packages/investing/src')}/$1/index.ts` },
+      { find: /^investing$/, replacement: `${resolve(rootDir, '../../packages/investing/src')}/index.ts` },
     ],
   },
 })

--- a/packages/investing/src/db/schema.ts
+++ b/packages/investing/src/db/schema.ts
@@ -772,6 +772,11 @@ export const stockQuoteCache = sqliteTable("stock_quote_cache", {
   low: real("low"),
   previousClose: real("previous_close"),
   volume: real("volume"),
+  // When this row was last written. Without it a cached quote has no age, so
+  // the `cacheTTL` every caller passes cannot be applied and a stale price is
+  // served forever. Nullable so rows written before this column existed read
+  // back as "age unknown" and are treated as expired (refetched once).
+  updatedAt: integer("updated_at", { mode: "timestamp" }),
 });
 
 // Stock Fundamentals - Store fundamental data like PE ratio, etc.

--- a/packages/investing/src/stocks/import-stock-names.ts
+++ b/packages/investing/src/stocks/import-stock-names.ts
@@ -505,4 +505,18 @@ async function main() {
     }
 }
 
-main();
+// This module is a build-time data generator: it scrapes NASDAQ/NYSE/AMEX, the
+// SEC and TradingView, then writes JSON to disk with `fs`. Calling `main()` on
+// import meant merely importing anything from this package fired those requests
+// — on every cold start of every API route that pulls in the stocks barrel, and
+// fatally so on Cloudflare Workers, where neither top-level network calls nor
+// `fs` are available. Run it only when invoked directly as a script.
+const isDirectInvocation =
+  typeof process !== 'undefined' &&
+  Array.isArray(process.argv) &&
+  process.argv[1] !== undefined &&
+  /import-stock-names(\.[cm]?[jt]s)?$/.test(process.argv[1]);
+
+if (isDirectInvocation) {
+  main();
+}

--- a/packages/investing/src/stocks/index.ts
+++ b/packages/investing/src/stocks/index.ts
@@ -6,7 +6,8 @@ export * from './stock-names';
 export * from './yfinance-wrapper';
 export * from './yahoo-finance-wrapper';
 export * from './sec-filing-api';
-export * from './import-stock-names';
+// './import-stock-names' is deliberately not re-exported: it is a build-time
+// scraper that writes files, not runtime API surface.
 export * from './finnhub-wrapper';
 export * from './types';
 export * from './unified-quote-service';

--- a/packages/investing/src/stocks/quote-cache-service.ts
+++ b/packages/investing/src/stocks/quote-cache-service.ts
@@ -14,6 +14,8 @@ import type { NormalizedQuote } from "./unified-quote-service";
 
 // Cache TTL in milliseconds
 const FUNDAMENTALS_CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
+/** Default freshness window for a cached quote when the caller names none. */
+export const QUOTE_CACHE_TTL = 60 * 1000; // 1 minute
 
 export interface CachedQuote {
   symbol: string;
@@ -49,9 +51,16 @@ export class QuoteCacheService {
   }
 
   /**
-   * Get cached quote if available
+   * Get cached quote if available and still fresh.
+   *
+   * @param symbol - Ticker to look up; matched case-insensitively.
+   * @param cacheTTL - Maximum age in milliseconds. Defaults to
+   *   {@link QUOTE_CACHE_TTL}. A row older than this — or one with no
+   *   timestamp, which is how rows written before the column existed read back
+   *   — is treated as a miss so the caller refetches. Pass `Infinity` to accept
+   *   a cached quote at any age.
    */
-  async getCachedQuote(symbol: string): Promise<CachedQuote | null> {
+  async getCachedQuote(symbol: string, cacheTTL: number = QUOTE_CACHE_TTL): Promise<CachedQuote | null> {
     try {
       const cached = await db
         .select()
@@ -64,6 +73,13 @@ export class QuoteCacheService {
       }
 
       const quote = cached[0];
+
+      if (Number.isFinite(cacheTTL)) {
+        const updatedAt = quote.updatedAt ? new Date(quote.updatedAt).getTime() : null;
+        if (updatedAt === null || Number.isNaN(updatedAt) || Date.now() - updatedAt > cacheTTL) {
+          return null;
+        }
+      }
 
       return {
         symbol: quote.symbol,
@@ -100,6 +116,7 @@ export class QuoteCacheService {
         low: this.roundPrice(quote.low),
         previousClose: this.roundPrice(quote.previousClose),
         volume: quote.volume,
+        updatedAt: new Date(),
       };
 
       await db
@@ -116,6 +133,7 @@ export class QuoteCacheService {
             low: roundedData.low,
             previousClose: roundedData.previousClose,
             volume: roundedData.volume,
+            updatedAt: roundedData.updatedAt,
           },
         });
     } catch (error: any) {
@@ -229,15 +247,20 @@ export class QuoteCacheService {
         filtered = filtered.filter((r) => r.date <= endDate);
       }
 
-      return filtered.map((r) => ({
-        date: r.date,
-        open: r.open,
-        high: r.high,
-        low: r.low,
-        close: r.close,
-        volume: r.volume || undefined,
-        adjustedClose: r.adjustedClose || undefined,
-      }));
+      // Sort oldest-first. Row order from the database is not guaranteed, and
+      // callers treat the first and last elements as the period bounds and feed
+      // the series straight to a chart, both of which need chronological order.
+      return filtered
+        .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0))
+        .map((r) => ({
+          date: r.date,
+          open: r.open,
+          high: r.high,
+          low: r.low,
+          close: r.close,
+          volume: r.volume || undefined,
+          adjustedClose: r.adjustedClose || undefined,
+        }));
     } catch (error: any) {
       console.error(`[QuoteCache] Error reading historical quotes for ${symbol}:`, error.message);
       return [];

--- a/packages/investing/src/stocks/unified-quote-service.ts
+++ b/packages/investing/src/stocks/unified-quote-service.ts
@@ -620,11 +620,25 @@ export class UnifiedQuoteService {
 export const unifiedQuoteService = new UnifiedQuoteService();
 
 // Export convenience functions
-export async function getQuote(symbol: string, options: { useCache?: boolean } = {}): Promise<QuoteServiceResponse> {
+/**
+ * Options accepted by the quote helpers.
+ *
+ * `cacheTTL` belongs in the type: the methods behind these wrappers have always
+ * taken it and callers have always passed it, but omitting it here made every
+ * such call a type error.
+ */
+export interface GetQuoteOptions {
+  /** Read from the quote cache before calling a provider. Defaults to true. */
+  useCache?: boolean;
+  /** Maximum age in ms for a cached quote to count as fresh. */
+  cacheTTL?: number;
+}
+
+export async function getQuote(symbol: string, options: GetQuoteOptions = {}): Promise<QuoteServiceResponse> {
   return unifiedQuoteService.getQuote(symbol, options);
 }
 
-export async function getQuotes(symbols: string[], options: { useCache?: boolean } = {}): Promise<QuotesServiceResponse> {
+export async function getQuotes(symbols: string[], options: GetQuoteOptions = {}): Promise<QuotesServiceResponse> {
   return unifiedQuoteService.getQuotes(symbols, options);
 }
 

--- a/packages/investing/src/stocks/unified-quote-service.ts
+++ b/packages/investing/src/stocks/unified-quote-service.ts
@@ -87,8 +87,17 @@ export class UnifiedQuoteService {
    * @param symbol - Stock symbol to fetch
    * @param options - Options object with useCache flag (default: true) and cacheTTL in milliseconds
    */
-  async getQuote(symbol: string, options: { useCache?: boolean; cacheTTL?: number } = {}): Promise<QuoteServiceResponse> {
+  async getQuote(rawSymbol: string, options: { useCache?: boolean; cacheTTL?: number } = {}): Promise<QuoteServiceResponse> {
     const { useCache = true, cacheTTL } = options;
+
+    // Normalize once, up front. The cache keys on the upper-cased symbol, so a
+    // request for "goog" would otherwise miss the entry written by "GOOG" and
+    // refetch on every call.
+    const symbol = typeof rawSymbol === 'string' ? rawSymbol.trim().toUpperCase() : '';
+    if (!symbol) {
+      return { success: false, error: 'A stock symbol is required' };
+    }
+
     console.log(`[UnifiedQuote] Fetching quote for ${symbol} (useCache: ${useCache}${cacheTTL ? `, cacheTTL: ${cacheTTL}ms` : ''})`);
 
     // Check cache first (unless bypassed)
@@ -116,12 +125,16 @@ export class UnifiedQuoteService {
         `alpaca timeout after 10s for ${symbol}`
       );
 
-      if (alpacaResult) {
+      // A response with no usable ask/bid is not a quote. Accepting it produced
+      // a $0 price that was reported as success and written to the cache, so
+      // every later reader saw a real stock priced at zero.
+      const alpacaPrice = Number((alpacaResult as any)?.ap ?? (alpacaResult as any)?.bp ?? 0);
+      if (alpacaResult && Number.isFinite(alpacaPrice) && alpacaPrice > 0) {
         // Alpaca returns quote data directly
         const quote = alpacaResult as any;
         const normalized: NormalizedQuote = {
           symbol,
-          price: quote.ap || quote.bp || 0, // ask price or bid price
+          price: alpacaPrice, // ask price or bid price
           change: null,
           changePercent: null,
           open: null,
@@ -157,11 +170,16 @@ export class UnifiedQuoteService {
         `yfinance timeout after 10s for ${symbol}`
       );
 
-      if (yfinanceResult.success && yfinanceResult.data) {
+      const yfPrice = Number(
+        (yfinanceResult.data as any)?.regularMarketPrice ??
+          (yfinanceResult.data as any)?.currentPrice ??
+          0,
+      );
+      if (yfinanceResult.success && yfinanceResult.data && Number.isFinite(yfPrice) && yfPrice > 0) {
         const data = yfinanceResult.data as any;
         const normalized: NormalizedQuote = {
           symbol,
-          price: data.regularMarketPrice || data.currentPrice || 0,
+          price: yfPrice,
           change: data.regularMarketChange || null,
           changePercent: data.regularMarketChangePercent || null,
           open: data.regularMarketOpen || data.open || null,


### PR DESCRIPTION
## Summary

This PR addresses multiple production issues in the stock data pipeline: partial ticker validation, cache TTL handling, chart zoom resolution, and data ordering bugs. It adds comprehensive test coverage for all stock API routes and introduces a debounce mechanism for symbol input to prevent request storms.

## Key Changes

### Stock Symbol Validation
- **New module** `lib/stocks/symbol.ts` provides centralized ticker validation with three levels:
  - Format validation (1-5 letters, optional class suffix like `.B` or `-A`)
  - Known symbol lookup against bundled dataset
  - Distinction between malformed tickers (400) and unlisted tickers (404)
- Applied to all stock API routes (`/api/stocks/quote`, `/api/stocks/historical`, `/api/stocks/quotes`)
- Prevents partial tickers from search boxes ("GOO", "GOOH") from reaching upstream providers

### Cache TTL Fix
- **`quote-cache-service.ts`**: Added `updatedAt` timestamp column to quote cache
- `getCachedQuote()` now respects caller-provided `cacheTTL` parameter (was previously ignored)
- Default TTL of 1 minute prevents stale quotes from being served indefinitely
- Rows without timestamps (pre-migration) are treated as stale

### Chart Zoom Resolution
- **`dynamic-stock-chart.tsx`**: Implements dynamic bar interval selection based on visible window
  - `intervalForSpan()` picks appropriate resolution (5m → 15m → 1h → 1d → 1wk)
  - `refetchForZoom()` reloads visible data at new resolution when zooming changes span
  - Debounced to prevent request spam during continuous wheel events
  - Indicators (RSI, MACD, etc.) recompute at zoomed resolution

### Data Ordering & Period Bounds
- **`historical-route.test.ts`**: Tests reveal cache branch that compared trading days vs calendar days (252 trading days ≠ 365 calendar days)
- **`quote-cache-service.ts`**: Historical quotes now sorted before use; period bounds read from first/last elements
- Prevents out-of-order data from charting incorrectly

### Input Debouncing
- **New hook** `lib/stocks/use-debounced-symbol.ts` settles symbol input before fetching
- Prevents request storms when typing in search boxes (e.g., "GOOGL" no longer fires requests for G, GO, GOO, GOOG, GOOGL)
- Validates format locally before debounce completes

### Request Limits
- **`quotes/route.ts`**: Added `MAX_SYMBOLS_PER_REQUEST = 50` ceiling
- Each symbol costs 1 quote + 3 historical requests; limit prevents blast radius

### UI Improvements
- **`video-showcase-section.tsx`**: New standalone section for agent walkthrough video
- Moved from small corner thumbnail to prominent titled section
- **`agents-team-section.tsx`**: Removed embedded video lightbox

## Test Coverage

Added comprehensive test suites:
- `historical-route.test.ts` (300 lines): Validation, range handling, cache behavior
- `quote-route.test.ts` (220 lines): Symbol validation, status codes (400/404/500)
- `quotes-route.test.ts` (194 lines): Batch request shape, limits, deduplication
- `search-routes.test.ts` (142 lines): Autocomplete and Yahoo search endpoints
- `settings-route.test.ts` (215 lines): Auth, secret masking, API key handling
- `unified-quote-service.test.ts` (215 lines): Symbol normalization, cache fallback, provider selection
- `quote-cache-service.test.ts` (207 lines): TTL enforcement, freshness checks, historical ordering
- `symbol.test.ts` (98 lines): Format validation, normalization, known symbol lookup

## Database Migration

- `0018_quote_cache_updated_at.sql`: Adds `updated_at` timestamp column to `stock_quote_cache` table
- Enables TTL-based cache expiration

## Notable Implementation Details

- Symbol normalization

https://claude.ai/code/session_01NVL3psEDkcLdVp1K2Ujoft