### PR TITLE
📝 docs(claude): add .claude/ agent docs and per-workspace CLAUDE.md files

### DIFF
--- a/.claude/architecture/conventions.md
+++ b/.claude/architecture/conventions.md
@@ -1,0 +1,106 @@
+# Conventions and General Rules
+
+## Language and style
+
+- TypeScript throughout, ESM. A few older files in `packages/investing`
+  (`debate-research/`, `llms.js`) are plain JS — leave them JS unless you are
+  converting the whole directory.
+- `tsconfig.base.json` at the root carries the shared compiler options; each
+  workspace extends it.
+- Match the surrounding file's style — naming, import order, comment density.
+  There is no repo-wide formatter enforcing it in CI.
+- **Comments explain why, not what.** The valuable comments in this codebase
+  record a constraint and its cause: why `packages/investing` reads D1 off
+  `globalThis` instead of importing `cloudflare:workers`, why every env var is
+  optional, why the npm publish job strips `always-auth`. `worker/index.ts`,
+  `wrangler.jsonc`, `env.ts` and `npm-publish.yml` are the house style — copy
+  that register.
+- Keep package boundaries clean: import a sibling from its public entry point,
+  never from its internals or its `src/`.
+
+## Generated code
+
+Two workspaces are generated from the app's OpenAPI spec and must not be
+hand-edited:
+
+- `packages/ai-broker-api-client` — `@hey-api/openapi-ts`; `*.gen.ts` files.
+- `packages/mcp-server` — `mcp-use`; 33 tools.
+
+To change either, change the route in `apps/ai-broker-web/app/api/` (and the
+spec at `app/api/openapi.json`), then regenerate.
+
+## Commits
+
+Gitmoji + conventional commits, lowercase subject, imperative mood:
+
+```
+✨ feat(admin): add an ADMIN_EMAILS-gated admin area with users and database controls
+🐛 fix(stocks): correct API validation, caching, and chart zoom resolution
+📝 docs(ai-broker): restructure docs into sections and adopt the shared Fumadocs template
+👷 ci: add Codecov coverage reporting across the monorepo
+🔒 docs: add SECURITY.md with private vulnerability reporting policy
+```
+
+Scope is the workspace or subsystem name. Version-bump commits are generated
+(`chore: bump published package versions [skip ci]`) — do not write them by
+hand.
+
+## Pull requests
+
+- Target `main`. One concern per PR; no drive-by refactors.
+- Say what changed, why, which workspaces are affected, and whether a published
+  package needs a version bump.
+- **Call out every change to a risk guard, threshold, or default position size
+  in its own line of the description.** See [trading.md](trading.md).
+- Include test results; screenshots for UI changes.
+- If you could not run a check, say so and why.
+
+## Tests
+
+- Add or update tests for every behaviour change and bug fix.
+- Run the touched workspace's own suite first — it is far faster than the root
+  run — then `bun run test` from the root.
+- Vitest everywhere except `packages/fin-data-api`, which is Jest. See
+  [monorepo.md](monorepo.md).
+- Tests run under Node. Passing tests do **not** prove the code runs on a
+  Cloudflare Worker; see [web-app.md](web-app.md).
+
+## CI
+
+| Workflow | Trigger | What it guards |
+| --- | --- | --- |
+| `test.yml` | push to `main`, PR, manual | `bun install` then `bun run test:coverage`, uploads the merged `coverage/lcov.info` to Codecov |
+| `npm-publish.yml` | push to `main`, manual | Publishes changed public packages (`investing`, `predictos`) |
+| `auto-merge-claude.yml` | PR | Enables auto-merge / auto-approve on Claude PRs, deletes the head branch on merge |
+| `auto-merge-and-create-prs.yml` | every 12h | Merges eligible PRs and opens PRs for branches that lack one |
+
+Codecov's project and patch checks are **informational** — a coverage dip never
+blocks a merge on its own. Codecov being down does not fail the job
+(`fail_ci_if_error: false`).
+
+## Publishing
+
+Only `investing` and `predictos` publish to npm. The other three workspaces are
+`"private": true`. Publishing runs on push to `main` and prefers **trusted
+publishing (OIDC)** — no secret at all — falling back to an `NPM_TOKEN` secret.
+npm granular tokens expire after at most 90 days, so a red publish job is
+usually an expired token, not a code problem; the workflow prints the exact
+remedy.
+
+## Documentation
+
+| If it is… | It goes in… |
+| --- | --- |
+| A guide someone outside the team would read | `apps/ai-broker-web/content/docs` (published to docs.autoinvestment.broker) |
+| How a workspace is used or built | That workspace's own `README.md` |
+| How an agent should work in a workspace | That workspace's own `CLAUDE.md` |
+| An implementation note, runbook, or decision record | `devdocs/` |
+
+## Security
+
+- Never commit secrets, API keys or broker credentials. Worker secrets go in
+  with `wrangler secret put`.
+- Vulnerability reporting policy is in [`SECURITY.md`](../../SECURITY.md) —
+  private disclosure, not a public issue.
+- Treat anything fetched from a venue, a scraped leaderboard, or an LLM as
+  untrusted input: validate before it reaches an order path.

--- a/.claude/architecture/monorepo.md
+++ b/.claude/architecture/monorepo.md
@@ -1,0 +1,83 @@
+# Monorepo Mechanics
+
+## Workspaces
+
+```json
+"workspaces": ["apps/*", "packages/*"]
+```
+
+Note what is *not* in that list: `third-party-trading-bots/` and `devdocs/`.
+Turbo only fans out into apps and packages.
+
+## Bun, and no lockfile
+
+`packageManager` pins `bun@1.3.11`. CI installs with
+[`oven-sh/setup-bun`](../../.github/workflows/test.yml) and runs a plain
+`bun install` — deliberately **without** `--frozen-lockfile`, because lockfiles
+are not committed in this repo. Do not add one; do not "fix" the missing
+lockfile. The README still shows `npm install` in places — that is stale, use
+`bun`.
+
+## The `dist` trap
+
+A workspace package is consumed by its `main`/`exports`, which point at built
+output — not at `src/`. So:
+
+> **Edit a package → rebuild it → then the app sees the change.**
+
+`bun run build` runs `turbo run build` with `dependsOn: ["^build"]`, so building
+the app builds its dependencies first. But `bun run dev` does **not** rebuild
+dependencies on the fly. If a change to `packages/investing` "doesn't show up"
+in the running app, you almost certainly skipped the rebuild:
+
+```bash
+bunx turbo run build --filter=investing
+```
+
+One deliberate exception in `turbo.json`: `ai-broker-web#build` overrides
+`dependsOn` to `[]` so the app's own Cloudflare build does not rebuild the whole
+graph.
+
+## Turbo task graph
+
+| Task | Notes |
+| --- | --- |
+| `build` | `dependsOn: ["^build"]`; outputs `dist/`, `build/`, `.source/`, `.wrangler/deploy/` |
+| `test` | `dependsOn: ["^build"]` — tests run against built dependencies |
+| `test:coverage` | Not build-dependent; outputs `coverage/` |
+| `lint`, `type-check` | `dependsOn: ["^build"]` |
+| `dev`, `start`, `preview`, `db:studio` | `cache: false`, `persistent: true` |
+| `deploy`, `db:*`, `cf-typegen`, `clean` | `cache: false` |
+
+`deploy` declares `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` in its
+`env` so turbo does not cache across credentials.
+
+## The test-runner split
+
+Almost everything is **Vitest**. `packages/fin-data-api` is **Jest** — the one
+exception, inherited from its OpenBB port. `packages/mcp-server` has no test
+script at all (it is generated).
+
+| Workspace | Runner |
+| --- | --- |
+| `apps/ai-broker-web` | Vitest |
+| `packages/investing` | Vitest (plus `test:debate` for the debate suite) |
+| `packages/predictos` | Vitest |
+| `packages/ai-broker-api-client` | Vitest |
+| `packages/fin-data-api` | **Jest** |
+
+Iterate inside the workspace — it is far faster than the root run:
+
+```bash
+bunx turbo run test --filter=investing
+cd packages/investing && bun run test
+```
+
+## Coverage
+
+`bun run test:coverage` runs every workspace's suite with coverage on, then
+`scripts/merge-coverage.mjs` merges the per-workspace LCOV reports into a single
+`coverage/lcov.info` with repo-root-relative paths. CI uploads exactly that one
+file to Codecov. Thresholds and the per-workspace component breakdown live in
+[`codecov.yml`](../../codecov.yml); project and patch checks are **informational**,
+so a coverage dip never blocks a merge on its own.

--- a/.claude/architecture/overview.md
+++ b/.claude/architecture/overview.md
@@ -1,0 +1,86 @@
+# Architecture Overview
+
+One deployed app, five libraries, and a pile of vendored prior art. Almost every
+behaviour that decides *what to trade* lives in a `packages/*` library and is
+merely *wired up* by the app that renders it. Finding the owning package is the
+first step of nearly every task here.
+
+## The product
+
+A multi-agent investment research desk with three halves:
+
+- **Research** — LLM analyst agents (fundamentals, news, technical, risk) that
+  independently research a ticker and then argue it out in a Bull vs. Bear
+  debate before a position is proposed.
+- **Signals** — algorithmic entry/exit strategies, technical indicators,
+  time-series correlation, and copy-trading leaderboards scraped from ZuluTrade
+  and NVSTly.
+- **Prediction markets** — Polymarket and Kalshi order books, event analysis
+  agents, and cross-venue arbitrage.
+
+## Request path, end to end
+
+```
+browser  ·  Google Play wrapper  ·  MCP client
+        │
+        ▼
+apps/ai-broker-web            Next.js on Cloudflare Workers (via vinext)
+  app/api/*                   route handlers — thin
+        │
+        ├─► packages/investing         agents, strategies, market data, brokers
+        │       ├─ trading-agents/     the analyst graph and its tools
+        │       ├─ debate-research/    Bull vs. Bear prompts, memory, LLM fan-out
+        │       ├─ algo-stategies/     entry/exit strategy definitions
+        │       ├─ alpaca/             broker client (+ MCP client)
+        │       ├─ leaders/            ZuluTrade + NVSTly copy-trading leaders
+        │       ├─ live-data/          Dukascopy FX/price feed
+        │       ├─ correlate/          time-series correlation
+        │       └─ prediction/         market sync, analysis, its own D1 tables
+        │
+        ├─► packages/predictos         prediction-market "super intelligence"
+        │       ├─ agents/             bookmaker, event analysis, mapper, order bots
+        │       ├─ clients/            Polymarket, Polyfactual, x402
+        │       ├─ data/               Polymarket + Kalshi market data
+        │       └─ arbitrage.ts        cross-platform arbitrage
+        │
+        └─► packages/fin-data-api      Congress.gov, Seeking Alpha, CFTC providers
+        │
+        ▼
+  D1 (Drizzle) · Workers AI · SEND_EMAIL binding · better-auth
+```
+
+`packages/investing` is deliberately runtime-agnostic: it runs both inside
+workerd and in plain Node scripts, so it reads the D1 binding off `globalThis`
+(`__CLOUDFLARE_ENV__`, set in `worker/index.ts`) rather than importing
+`cloudflare:workers`. Keep it that way — importing `cloudflare:workers` there
+breaks both the Node scripts and the client bundle.
+
+## Apps
+
+| App | Stack | Owns |
+| --- | --- | --- |
+| `ai-broker-web` | Next.js + vinext → Cloudflare Workers, D1 via Drizzle | The deployed product: routes, `/api`, auth, admin, docs, DB schema and migrations. See [web-app.md](web-app.md). |
+
+Route groups under `app/`: `dashboard`, `markets`, `stock`, `portfolio`,
+`predict`, `debate`, `leaders`, `survey`, `legal`, `admin` (gated by
+`ADMIN_EMAILS`), `login`, and `docs` (Fumadocs).
+
+## Packages
+
+| Package | Published | What it owns |
+| --- | --- | --- |
+| `investing` | npm | Trading agents, debate research, algo strategies, Alpaca, leaderboards, live data, correlation, prediction-market sync. The heart of the repo. |
+| `predictos` | npm | Prediction-market multi-agent analysis, Polymarket/Kalshi clients, cross-platform arbitrage. Adapted from PredictionXBT/PredictOS (MIT). |
+| `fin-data-api` | — | TypeScript port of OpenBB finance APIs: Congress, earnings calendars, CFTC. Zod-validated, Scalar OpenAPI docs. The one Jest workspace. |
+| `ai-broker-api-client` | private | Typed client **generated** from the OpenAPI spec with `@hey-api/openapi-ts`. Do not hand-edit `*.gen.ts`. |
+| `mcp-server` | — | MCP server **generated** from the same OpenAPI spec (33 tools) via `mcp-use`. |
+
+## Not part of the build
+
+- **`third-party-trading-bots/`** — vendored open-source bots kept as prior art
+  for position sizing, LLM batching, and venue normalization. Outside the
+  workspace globs; turbo never fans out into it; nothing here deploys. Each
+  subdirectory keeps its own upstream license. Read it, don't edit it, don't
+  import from it.
+- **`devdocs/`** — internal engineering notes, runbooks and decision records.
+  User-facing docs go in `apps/ai-broker-web/content/docs` instead.

--- a/.claude/architecture/trading.md
+++ b/.claude/architecture/trading.md
@@ -1,0 +1,77 @@
+# The Trading Domain
+
+This is the part of the repo where a bug costs money. Read this before changing
+anything that proposes, sizes, or executes a position.
+
+## Rules that are not negotiable
+
+1. **Never weaken a risk guard to make something pass.** Position caps,
+   confidence ceilings, minimum-entry prices, edge limits and stop-losses are
+   the product, not obstacles. If a test fails against a guard, the change is
+   wrong until proven otherwise.
+2. **Never widen a default.** Changing a default position size, leverage, or
+   threshold is a product decision. Surface it in the PR explicitly; do not slip
+   it in alongside a refactor.
+3. **Paper-trade paths and live paths must stay distinguishable.** Do not
+   collapse a dry-run branch into the live one "to reduce duplication".
+4. **Every threshold change needs a test that pins the new number**, so the next
+   refactor cannot drift it silently.
+5. **Money maths is integer-or-decimal-careful.** Watch rounding direction on
+   position sizing — round *down* into a position, never up.
+
+## Where the logic lives
+
+### `packages/investing`
+
+| Directory | What it owns |
+| --- | --- |
+| `trading-agents/` | The analyst agent graph — `agents/`, `tools/`, `graph/`, and its own `README.md`. Start there. |
+| `debate-research/` | Bull vs. Bear: prompts (`prompts/`), memory, LLM fan-out (`llms.js`), FX normalization, health checks |
+| `algo-stategies/` | Entry/exit strategy definitions (`algo-strategies.json`) and the TradingView scraper |
+| `alpaca/` | Broker client and the Alpaca MCP client — the execution edge |
+| `leaders/` | Copy-trading leaderboards: ZuluTrade (`zulu.ts`), NVSTly (`nvsty-leaders.ts`) |
+| `live-data/` | Dukascopy price/FX feed and its symbol table |
+| `correlate/` | Time-series correlation between instruments |
+| `stocks/`, `stock-names-data/` | Instrument metadata and name resolution |
+| `prediction/` | Prediction-market sync, analysis, API and its own D1 tables |
+| `qwksearch/`, `trending-topics/` | News and web research feeding the news analyst |
+| `llm/` | Provider calls shared by the agents |
+
+The debate suite has its own script because it is slow and network-shaped:
+
+```bash
+cd packages/investing && bun run test:debate
+```
+
+### `packages/predictos`
+
+Prediction-market intelligence, adapted from PredictionXBT/PredictOS (MIT — keep
+the attribution intact).
+
+| File / directory | What it owns |
+| --- | --- |
+| `agents/bookmaker-agent.ts` | Pricing a market like a book |
+| `agents/event-analysis-agent.ts` | Reading an event's resolution criteria |
+| `agents/mapper-agent.ts` | Mapping equivalent markets across venues — the precondition for arbitrage |
+| `agents/polymarket-*.ts` | Position tracking, order placement, the up/down 15-minute limit bot |
+| `clients/`, `data/` | Polymarket, Kalshi, Polyfactual, x402 |
+| `arbitrage.ts` | Cross-platform arbitrage |
+| `ai/` | Grok / OpenAI / BlockRun calls and their prompts |
+
+Venue semantics differ (tick size, fee model, resolution rules, settlement
+timing). A mapper that treats two markets as equivalent when they are not turns
+"arbitrage" into a directional bet — treat `mapper-agent.ts` as safety-critical.
+
+## Prior art: `third-party-trading-bots/`
+
+Vendored, unbuilt, undeployed reference implementations — how other people size
+positions, batch LLM calls, gate on liquidity, and normalize venue APIs. Its
+`README.md` summarizes what each bot is worth studying for. Read it when you are
+about to invent one of those wheels. Do not edit it, import from it, lint it, or
+wire it into the build.
+
+## Disclosure
+
+This is research tooling, not investment advice, and the published docs say so
+(`content/docs/reference/risk-disclosure`). Do not write copy in the UI or docs
+that implies guaranteed returns or removes that framing.

--- a/.claude/architecture/web-app.md
+++ b/.claude/architecture/web-app.md
@@ -1,0 +1,109 @@
+# The Web App — `apps/ai-broker-web`
+
+The only deployed artifact. Next.js (App Router) built by **vinext** and run on
+**Cloudflare Workers**. Cloudflare is the only platform this app targets.
+
+## Shape
+
+```
+apps/ai-broker-web/
+  app/            routes + route handlers (app/api/*)
+  components/     app-local UI (shadcn; components.json)
+  lib/            auth, db, ai, alpaca, admin, openapi, fumadocs, email, kyc…
+  content/docs/   the published user documentation (Fumadocs MDX)
+  migrations/     D1 migrations, applied by wrangler
+  worker/index.ts the Workers entrypoint — wraps vinext, adds cron routing
+  wrangler.jsonc  bindings, crons, vars
+  env.ts          typed env (@t3-oss/env-nextjs + zod)
+```
+
+Route handlers under `app/api/` are meant to stay **thin** — parse, authorize,
+delegate to `packages/investing` or `packages/predictos`, serialize. Trading
+logic does not belong in a route.
+
+## Bindings
+
+| Binding | What it is |
+| --- | --- |
+| `DB` | D1 database `ai-broker-db`, `migrations_dir: migrations` |
+| `ASSETS` | Client bundle from `dist/client`; `not_found_handling: "none"` so vinext routes unmatched paths through the Worker |
+| `SEND_EMAIL` | Cloudflare Email Workers — the **only** outbound mail path (auth verification, password reset, team invitations). Needs Email Routing on the zone and a verified sender domain. |
+
+`compatibility_flags: ["nodejs_compat", "global_fetch_strictly_public"]`.
+Page-level ISR runs through the vinext CDN cache adapter (`"cache": {"enabled": true}`).
+
+## Scheduled work
+
+Workers cron triggers replace the old Vercel crons. `wrangler.jsonc` declares
+the schedules and `worker/index.ts` maps each one to an API route, dispatched
+through the same fetch handler with the `CRON_SECRET` bearer token the routes
+already expect:
+
+| Schedule | Route |
+| --- | --- |
+| `0 0 * * *` | `/api/cron/sync-markets` |
+| `15 0 * * *` | `/api/cron/refresh-quotes` |
+
+**Adding a cron means editing two places** — the `triggers.crons` array *and*
+the `CRON_ROUTES` map in `worker/index.ts`. A schedule with no mapped route just
+logs a warning and does nothing. Other routes exist under `app/api/cron/`
+(`sync-polymarket`, `sync-zulu`) and are invoked directly rather than scheduled.
+
+## Database
+
+Drizzle + D1 (SQLite dialect, `d1-http` driver). Schema: `lib/db/schema.ts`.
+`packages/investing/src/prediction/db` carries the prediction-market tables.
+
+```bash
+bun run db:generate        # drizzle-kit generate — schema only, no credentials needed
+bun run db:push            # talks to D1, needs credentials
+bun run db:studio          # persistent
+bun run db:migrate:local   # local miniflare D1 used by vinext dev/preview
+bun run db:migrate:remote  # production D1
+```
+
+`db:push` and `db:studio` need `CLOUDFLARE_ACCOUNT_ID` and
+`CLOUDFLARE_D1_TOKEN` (or `CLOUDFLARE_API_TOKEN`). A local `.env` wins over the
+monorepo-root `.env`.
+
+**Never edit an applied migration.** Change `lib/db/schema.ts`, run
+`db:generate`, and commit the new migration file.
+
+## Auth
+
+better-auth (`lib/auth/`), email/password plus Google OAuth, sessions in D1.
+`/admin` is gated by a comma-separated `ADMIN_EMAILS` allowlist — with neither
+`ADMIN_EMAILS` nor `ADMIN_EMAIL` set, **nobody** is an admin
+(`lib/auth/admin.ts`). Operational notes on cookies and the OAuth callback
+origin are in [`devdocs/AUTH_CONFIGURATION.md`](../../devdocs/AUTH_CONFIGURATION.md).
+
+## Environment
+
+`env.ts` validates with zod, and **everything is optional** so builds and
+preview environments never fail validation — call sites keep their own runtime
+guards. Do not make a variable required to "catch" a misconfiguration; guard at
+the call site instead.
+
+Secrets are Worker secrets, set with `wrangler secret put <NAME>`:
+`BETTER_AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`,
+`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `CRON_SECRET`. Broker and LLM
+keys go the same way. Never commit any of them.
+
+## Deploy
+
+```bash
+bun run build     # turbo build; then scripts/write-root-deploy-config.mjs
+bun run deploy    # vinext-cloudflare deploy
+bun run cf-typegen  # regenerate cloudflare-env.d.ts after changing bindings
+```
+
+Change a binding in `wrangler.jsonc` → run `cf-typegen` → commit the updated
+`cloudflare-env.d.ts`.
+
+## Testing against Workers
+
+Tests run under Node with Vitest. **Passing tests do not prove the code runs on
+a Worker.** Node APIs outside `nodejs_compat`, anything that assumes a
+filesystem, and long-running CPU work will pass locally and fail in production.
+Exercise the real thing with `bun run preview` (local miniflare D1) before
+deploying anything that touches the Worker entrypoint, bindings, or crons.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(bun install)",
+      "Bash(bun run build:*)",
+      "Bash(bun run test:*)",
+      "Bash(bun run lint:*)",
+      "Bash(bun run type-check:*)",
+      "Bash(bunx turbo run:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "deny": [
+      "Read(./**/.env)",
+      "Read(./**/.env.*)",
+      "Read(./**/.dev.vars)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ docs/.next
 **/coverage/
 *.lcov
 *lock*
-.claude/
 # turborepo
 .turbo/
 **/.turbo/
@@ -47,7 +46,6 @@ yarn-error.log*
 # cloudflare
 .wrangler/
 **/.wrangler/
-.claude
 .vscode
 
 # typescript
@@ -69,3 +67,10 @@ local.db
 drizzle/
 .source/
 **/.source/
+
+.claude/*
+# Agent docs for Claude Code — checked in on purpose (see CLAUDE.md)
+!.claude/architecture
+!.claude/settings.json
+.claude/settings.local.json
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,95 @@
+# CLAUDE.md — AI Broker Investing Agent
+
+Orientation for Claude agents working in this repository. Read this first; the
+detailed notes live in [`.claude/architecture/`](.claude/architecture/) and are
+linked from each section below.
+
+A **Bun + Turborepo monorepo**. Multi-agent trading research — LLM analyst
+agents that debate a position, algorithmic entry/exit signals, copy-trading
+leaderboards and prediction-market arbitrage — shipped as one Next.js app on
+Cloudflare Workers at [autoinvestment.broker](https://autoinvestment.broker).
+
+> **This code reasons about money.** Trading logic, position sizing and risk
+> limits are not ordinary business rules — a wrong sign or an off-by-one on a
+> threshold moves real capital. Never loosen a risk guard, widen a position cap
+> or disable a validation to make a test pass.
+
+## Ground rules
+
+1. **Bun, never npm or yarn.** `packageManager` pins `bun@1.3.11` and CI
+   installs with it. The README's `npm` examples are stale — use `bun`.
+2. **Lockfiles are deliberately not committed here.** CI runs a plain
+   `bun install` *without* `--frozen-lockfile`. Do not add `bun.lock`.
+3. **Find the owning package before you edit.** Trading behaviour lives in
+   `packages/investing` and `packages/predictos`, not in the app that renders
+   it. See [`architecture/overview.md`](.claude/architecture/overview.md).
+4. **Packages are consumed as built `dist/`, not live source.** A package edit
+   that "doesn't show up" almost always means it was not rebuilt. See
+   [`architecture/monorepo.md`](.claude/architecture/monorepo.md).
+5. **`third-party-trading-bots/` is vendored reference material.** It is
+   outside the workspace globs, turbo never fans out into it, and nothing there
+   ships. Read it as prior art; do not edit it, import from it, or fix its
+   lint.
+6. **Generated code is not hand-edited.** `packages/ai-broker-api-client` is
+   generated from the OpenAPI spec and `packages/mcp-server` from the same
+   spec — change the source route, then regenerate.
+7. **Respect package boundaries.** Import from a package's public entry point,
+   never reach into its internals.
+8. **Never commit secrets**, API keys, broker credentials, or build output.
+   Broker and LLM keys belong in Worker secrets — see
+   [`architecture/web-app.md`](.claude/architecture/web-app.md).
+
+## Where things live
+
+| You want to change… | Go to |
+| --- | --- |
+| Trading agents, signals, market data, brokers | `packages/investing` |
+| Prediction markets, cross-venue arbitrage | `packages/predictos` |
+| Congress / earnings / CFTC data providers | `packages/fin-data-api` |
+| The typed API client (generated) | `packages/ai-broker-api-client` |
+| The MCP server (generated) | `packages/mcp-server` |
+| Routes, `/api` handlers, auth, D1 schema, crons | `apps/ai-broker-web` |
+| User-facing documentation | `apps/ai-broker-web/content/docs` |
+| Internal runbooks and decision records | `devdocs/` |
+
+Full map: [`architecture/overview.md`](.claude/architecture/overview.md) ·
+trading domain: [`architecture/trading.md`](.claude/architecture/trading.md).
+
+## Commands
+
+```bash
+bun install                    # never npm/yarn
+bun run dev                    # turbo run dev
+bun run build                  # turbo run build across the graph
+bun run test                   # turbo run test
+bun run test:coverage          # per-workspace coverage, merged to coverage/lcov.info
+bun run type-check             # tsc --noEmit everywhere
+
+bunx turbo run test --filter=investing     # much faster while iterating
+```
+
+Database and deploy commands live in
+[`architecture/web-app.md`](.claude/architecture/web-app.md).
+
+## Before you open a PR
+
+- Run the touched workspace's own tests, then `bun run test` from the root.
+- Run `bun run build` if you changed anything a sibling workspace imports.
+- Add or update a test for every behaviour change — especially anything that
+  sizes a position, sets a threshold, or decides a trade.
+- Update the workspace's `README.md` and its `CLAUDE.md` when behaviour or
+  public API changes.
+- Commit style is **gitmoji + conventional commits**:
+  `✨ feat(scope): what changed`. See
+  [`architecture/conventions.md`](.claude/architecture/conventions.md).
+- Target `main`. Keep the PR focused; no drive-by refactors.
+
+## Detailed notes
+
+| Note | Covers |
+| --- | --- |
+| [overview.md](.claude/architecture/overview.md) | System architecture, the request path, every package and app |
+| [monorepo.md](.claude/architecture/monorepo.md) | Workspaces, the `dist` trap, turbo, the test-runner split |
+| [web-app.md](.claude/architecture/web-app.md) | The deployed Cloudflare app: Worker, D1, auth, crons, deploy, migrations |
+| [trading.md](.claude/architecture/trading.md) | Agents, strategies, brokers, prediction markets, and the rules around risk |
+| [conventions.md](.claude/architecture/conventions.md) | Code style, commits, PRs, CI, publishing, security |

--- a/apps/ai-broker-web/CLAUDE.md
+++ b/apps/ai-broker-web/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md — `ai-broker-web`
+
+The only deployed artifact: Next.js (App Router) built with **vinext** and run
+on **Cloudflare Workers**. Full notes in
+[`../../.claude/architecture/web-app.md`](../../.claude/architecture/web-app.md).
+
+## Keep route handlers thin
+
+`app/api/*` handlers parse, authorize, delegate, serialize. Trading logic lives
+in `packages/investing` and `packages/predictos` — if you are writing a decision
+rule inside a route handler, it is in the wrong file.
+
+## Things that bite
+
+- **Bindings changed → run `bun run cf-typegen`** and commit the updated
+  `cloudflare-env.d.ts`.
+- **Adding a cron means two edits**: the schedule in `wrangler.jsonc`
+  (`triggers.crons`) *and* the `CRON_ROUTES` map in `worker/index.ts`. An
+  unmapped schedule logs a warning and silently does nothing.
+- **Never edit an applied migration.** Change `lib/db/schema.ts`, run
+  `bun run db:generate`, commit the new file in `migrations/`.
+- **Every env var in `env.ts` is optional on purpose** so builds and previews
+  never fail validation. Guard at the call site; don't make one required.
+- **`/admin` is gated by `ADMIN_EMAILS`** (comma-separated). With neither
+  `ADMIN_EMAILS` nor `ADMIN_EMAIL` set, nobody is an admin — that is the safe
+  default, keep it.
+- **Vitest runs under Node — it does not prove the Worker works.** Use
+  `bun run preview` (local miniflare D1) before shipping anything touching the
+  Worker entrypoint, bindings, or crons.
+
+## Layout
+
+| Path | Owns |
+| --- | --- |
+| `app/` | Routes: `dashboard`, `markets`, `stock`, `portfolio`, `predict`, `debate`, `leaders`, `survey`, `legal`, `admin`, `login`, `docs` |
+| `app/api/` | Route handlers, including `api/cron/*` and `api/openapi.json` |
+| `components/` | App-local UI (shadcn; see `components.json`) |
+| `lib/` | `auth/`, `db/`, `ai/`, `alpaca/`, `admin/`, `openapi/`, `fumadocs/`, `email/`, `kyc/` |
+| `content/docs/` | The **published** user documentation (docs.autoinvestment.broker) |
+| `migrations/` | D1 migrations, applied by wrangler |
+| `worker/index.ts` | Workers entrypoint: wraps vinext, routes crons, sets `__CLOUDFLARE_ENV__` |
+
+## Commands
+
+```bash
+bun run dev              # vinext dev
+bun run preview          # build + vite preview against local miniflare D1
+bun run test             # vitest
+bun run type-check
+bun run db:generate      # after editing lib/db/schema.ts
+bun run db:migrate:local
+bun run deploy           # vinext-cloudflare deploy
+```

--- a/packages/ai-broker-api-client/CLAUDE.md
+++ b/packages/ai-broker-api-client/CLAUDE.md
@@ -1,0 +1,29 @@
+# CLAUDE.md — `ai-broker-api-client`
+
+Private (not published from CI). A typed TypeScript client for the Auto
+Investment Broker API, **generated** from the project's OpenAPI specification
+with [`@hey-api/openapi-ts`](https://heyapi.dev).
+
+## Do not hand-edit the generated files
+
+`src/client.gen.ts`, `src/sdk.gen.ts`, `src/types.gen.ts` and `src/core/` are
+output. Editing them works until the next regeneration silently reverts it.
+
+To change the client, change the API:
+
+1. Edit the route in `apps/ai-broker-web/app/api/…`.
+2. Update the spec at `apps/ai-broker-web/app/api/openapi.json`.
+3. Regenerate: `cd packages/ai-broker-api-client && bun run build:api`.
+4. Commit the regenerated files as part of the same change.
+
+Hand-written wrappers, if you need one, go in a new non-`.gen` file next to
+`src/index.ts` — never inside the generated ones.
+
+## Commands
+
+```bash
+cd packages/ai-broker-api-client
+bun run build:api      # regenerate from the OpenAPI spec
+bun run test           # vitest
+bun run test:api
+```

--- a/packages/fin-data-api/CLAUDE.md
+++ b/packages/fin-data-api/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md — `fin-data-api`
+
+Private (not published). A TypeScript port of the OpenBB Finance APIs:
+Congressional trading data, earnings calendars, CFTC reports, and friends,
+behind a Zod-validated API with Scalar OpenAPI documentation.
+
+## The one thing to remember
+
+**This workspace runs on Jest, not Vitest.** It is the only one in the repo that
+does. `bun run test` here is `jest`. Don't "standardize" it onto Vitest as a
+drive-by — the port's test suite came with it.
+
+## Layout
+
+| Path | Owns |
+| --- | --- |
+| `src/api/` | Route definitions and the OpenAPI surface |
+| `src/providers/` | One module per upstream data source (Congress.gov, Seeking Alpha, CFTC, …) |
+| `src/types/` | Zod schemas and inferred types |
+| `src/utils/` | Shared helpers |
+| `src/__tests__/` | Jest suites |
+
+## Rules
+
+- Every provider response is validated with Zod at the boundary. Upstream
+  financial APIs change shape without warning and return partial data — parse,
+  don't cast.
+- One provider per file. A new data source is a new module in `providers/`, not
+  a branch inside an existing one.
+- Keep the OpenAPI surface honest: it is what the generated
+  `ai-broker-api-client` and `mcp-server` are built from.
+
+## Commands
+
+```bash
+cd packages/fin-data-api
+bun run test           # jest
+bun run test:coverage
+bun run type-check
+bun run dev
+```

--- a/packages/investing/CLAUDE.md
+++ b/packages/investing/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md — `investing`
+
+Published to npm. The heart of the repo: everything that decides *what to
+trade*. The app renders this package; it does not reimplement it.
+
+Read [`../../.claude/architecture/trading.md`](../../.claude/architecture/trading.md)
+before changing anything that proposes, sizes, or executes a position.
+
+## Public surface
+
+Import from a subpath export, never from `src/`:
+
+| Entry | What it gives you |
+| --- | --- |
+| `investing` | The barrel — db schemas, trading agents, Alpaca client, stocks, prediction, predictos, strategies, leaders, correlation |
+| `investing/trading-agents` | The analyst agent graph |
+| `investing/alpaca` | Broker client |
+| `investing/stocks` | Instrument data and name resolution |
+| `investing/prediction` | Prediction-market sync, analysis, tables |
+| `investing/predictos` | Re-export of the PredictOS core |
+| `investing/constants`, `investing/utils` | Shared constants and helpers |
+| `investing/data/*` | Raw data files, served unbuilt |
+
+Adding a new subsystem means adding a subpath export — do not let consumers
+deep-import.
+
+## Runtime constraint
+
+This package runs **both** on Cloudflare Workers and in plain Node scripts. It
+therefore reads the D1 binding off `globalThis.__CLOUDFLARE_ENV__` (set by the
+app's `worker/index.ts`) rather than importing `cloudflare:workers`, which only
+resolves inside workerd and would break both the Node scripts and the client
+bundle. **Do not import `cloudflare:workers` here.**
+
+`drizzle-orm` is a peer dependency — the `db` exports are optional by design.
+
+## Layout
+
+| Directory | Owns |
+| --- | --- |
+| `trading-agents/` | Agent graph: `agents/`, `tools/`, `graph/`. Has its own `README.md` and `IMPROVEMENTS.md`. |
+| `debate-research/` | Bull vs. Bear — `prompts/`, `memory.js`, `llms.js`, FX normalization, health check. Still plain JS. |
+| `algo-stategies/` | `algo-strategies.json` + the TradingView scraper. (The directory name is misspelled upstream; leave it.) |
+| `alpaca/` | Broker REST client and the Alpaca MCP client |
+| `leaders/` | ZuluTrade and NVSTly copy-trading leaderboards |
+| `live-data/` | Dukascopy feed + symbol table |
+| `correlate/` | Time-series correlation / XGBoost prediction statistics |
+| `prediction/` | Market sync, analysis, API, and its own D1 tables |
+| `stocks/`, `stock-names-data/` | Instruments and name resolution |
+| `qwksearch/`, `trending-topics/` | News/web research feeding the news analyst |
+| `llm/` | Shared provider calls |
+| `db/` | Drizzle schema, D1 client, `d1-http` client |
+
+## Commands
+
+```bash
+cd packages/investing
+bun run test              # vitest
+bun run test:debate       # the debate suite — slow, network-shaped
+bun run build             # rebuild before the app can see your change
+```
+
+Data-import and sync scripts (`import:leaders`, `import:stocks`,
+`sync:high-volume-markets`, `sync:trade-history`) talk to live venues and D1.
+Read [`devdocs/sync-scripts.md`](../../devdocs/sync-scripts.md) and
+[`devdocs/HIGH_VOLUME_SYNC_GUIDE.md`](../../devdocs/HIGH_VOLUME_SYNC_GUIDE.md)
+before running one; they are not idempotent no-ops.
+
+## Rules
+
+- Rebuild after editing — the app consumes `dist/`, not `src/`.
+- A threshold or position-size change needs a test pinning the new number.
+- Treat venue responses, scraped leaderboards and LLM output as untrusted input;
+  validate before anything reaches an order path.

--- a/packages/mcp-server/CLAUDE.md
+++ b/packages/mcp-server/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md — `api-mcp-server`
+
+Private (not published). An MCP server exposing the broker API as 33 tools,
+**generated** from the same OpenAPI specification as
+`packages/ai-broker-api-client`, using the [mcp-use](https://mcp-use.com)
+framework. Streamable HTTP transport, with a built-in inspector at
+`/inspector`.
+
+## Do not hand-edit
+
+`src/tools-config.js`, `src/http-client.js` and `src/index.js` are generated
+output. Change the route and the spec in `apps/ai-broker-web`, then regenerate.
+A hand-edit here survives exactly until the next regeneration.
+
+There is **no test script** in this workspace, and that is deliberate — it has
+no hand-written behaviour to test. If you find yourself wanting one, the logic
+you are adding probably belongs in `packages/investing` instead.
+
+## Commands
+
+```bash
+cd packages/mcp-server
+bun run dev
+bun run start
+```

--- a/packages/predictos/CLAUDE.md
+++ b/packages/predictos/CLAUDE.md
@@ -1,0 +1,53 @@
+# CLAUDE.md — `predictos`
+
+Published to npm. Prediction-market "super intelligence": multi-agent market
+analysis, venue clients, and cross-platform arbitrage.
+
+Adapted from [PredictOS](https://github.com/PredictionXBT/PredictOS) by
+PredictionXBT (MIT, © 2025), refactored from Deno/Supabase edge functions into
+Node/TypeScript ESM. **Keep the upstream attribution and license intact** in
+`README.md` and the source headers.
+
+Read [`../../.claude/architecture/trading.md`](../../.claude/architecture/trading.md)
+before changing anything on an order path.
+
+## Public surface
+
+| Entry | What it gives you |
+| --- | --- |
+| `predictos` | The barrel |
+| `predictos/agents` | Bookmaker, event analysis, mapper, Polymarket position/order bots |
+| `predictos/arbitrage` | Cross-platform arbitrage |
+| `predictos/data/polymarket`, `predictos/data/kalshi` | Venue market data |
+| `predictos/ai` | Grok / OpenAI / BlockRun calls and prompts |
+
+## Safety-critical: `agents/mapper-agent.ts`
+
+Arbitrage is only arbitrage if the two markets really are the same bet. Venues
+differ on tick size, fee model, resolution criteria and settlement timing — a
+mapper that calls two markets equivalent when they are not turns a hedge into a
+naked directional position. Changes here need explicit tests for the
+near-miss cases, not just the happy path.
+
+## Layout
+
+| Path | Owns |
+| --- | --- |
+| `agents/bookmaker-agent.ts` | Prices a market like a book |
+| `agents/event-analysis-agent.ts` | Reads an event's resolution criteria |
+| `agents/mapper-agent.ts` | Cross-venue market equivalence |
+| `agents/polymarket-position-tracker.ts` | Open position state |
+| `agents/polymarket-put-order.ts`, `agents/polymarket-updown-15-limit-order-bot.ts` | Order placement |
+| `agents/polyfactual-research.ts`, `clients/polyfactual.ts` | Research feed |
+| `clients/x402.ts`, `agents/x402-seller.ts` | x402 payments |
+| `data/` | Polymarket and Kalshi market data |
+| `events.ts`, `types.ts` | Shared event and type definitions |
+
+## Commands
+
+```bash
+cd packages/predictos
+bun run test        # vitest
+bun run typecheck
+bun run build       # rebuild before consumers see your change
+```


### PR DESCRIPTION
Adopts the layout `qwksearch-research-agent` already uses: a short root `CLAUDE.md` operating manual backed by deeper notes in `.claude/architecture/`, plus one `CLAUDE.md` per workspace.

## What's here

- `.claude/architecture/` — `overview.md`, `monorepo.md`, `web-app.md`, `trading.md`, `conventions.md`
- `CLAUDE.md` in each of the five packages and in `apps/ai-broker-web`
- `.claude/settings.json` pre-approving the repo's own build/test commands and denying reads of `.env` / `.dev.vars`
- `.gitignore` un-ignores `.claude/architecture` and `.claude/settings.json` (it previously ignored `.claude/` wholesale, so none of this would have been committed), while keeping `settings.local.json` and `CLAUDE.local.md` local

## What the notes actually say

Written from the source rather than restating the README, so they carry the things that cost time here:

- Lockfiles are deliberately **not** committed — CI runs `bun install` without `--frozen-lockfile`. The README's `npm install` examples are stale.
- `packages/investing` reads D1 off `globalThis.__CLOUDFLARE_ENV__` instead of importing `cloudflare:workers`, because it runs in Node scripts too.
- Adding a cron means editing **two** places: `triggers.crons` in `wrangler.jsonc` *and* the `CRON_ROUTES` map in `worker/index.ts`. An unmapped schedule logs a warning and does nothing.
- Every env var in `env.ts` is optional on purpose; `/admin` defaults to nobody when `ADMIN_EMAILS` is unset.
- Vitest everywhere except `packages/fin-data-api`, which is Jest.
- `ai-broker-api-client` and `mcp-server` are generated from the OpenAPI spec and must not be hand-edited.
- `third-party-trading-bots/` is outside the workspace globs — prior art to read, not code to edit.

`trading.md` is the one that doesn't have a counterpart in the sibling repos: it records that risk guards, position caps and thresholds are the product rather than refactorable details, that a threshold change needs a test pinning the new number, and that `predictos`' `mapper-agent.ts` is safety-critical because a wrong cross-venue equivalence turns a hedge into a naked directional position.

## Notes

Documentation only — no code, config or dependency changes. The `.gitignore` edit is the only change outside `CLAUDE.md`/`.claude/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EoGK1G8bnF6riGQekWLtYr

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoGK1G8bnF6riGQekWLtYr)_