### PR TITLE
📝 docs(readme): add an "Open in StackBlitz" badge to the README badge rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
     <a href="https://docs.autoinvestment.broker/"><img src="https://img.shields.io/badge/Docs-blue?logo=ReadTheDocs&logoColor=white" alt="Documentation" /></a>
     <a href="https://autoinvestment.broker/api/docs"><img src="https://img.shields.io/badge/API-blue?logo=fastapi&logoColor=white" alt="API badge"></a>
     <a href="https://deploy.workers.cloudflare.com/?url=https://github.com/OpenSourceAGI/ai-broker-investing-agent" target="_blank" rel="noopener noreferrer"><img height="24px" src="https://deploy.workers.cloudflare.com/button" alt="Deploy to Cloudflare Workers" /></a>
+    <a href="https://stackblitz.com/github/OpenSourceAGI/ai-broker-investing-agent/tree/main/packages/investing"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
 <br />
     <a href="https://github.com/OpenSourceAGI/ai-broker-investing-agent/stargazers"><img alt="GitHub Stars" src="https://img.shields.io/github/stars/OpenSourceAGI/ai-broker-investing-agent" /></a>
     <a href="https://www.npmjs.com/package/investing"><img src="https://img.shields.io/npm/dm/investing.svg" alt="NPM Monthly Downloads"></a>

--- a/packages/ai-broker-api-client/README.md
+++ b/packages/ai-broker-api-client/README.md
@@ -5,6 +5,7 @@ API, generated from the project's OpenAPI specification with
 [`@hey-api/openapi-ts`](https://heyapi.dev).
 
 [![npm](https://img.shields.io/npm/v/ai-broker-api-client)](https://npmjs.org/package/ai-broker-api-client)
+[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/OpenSourceAGI/ai-broker-investing-agent/tree/main/packages/ai-broker-api-client)
 
 ## Install
 

--- a/packages/investing/README.md
+++ b/packages/investing/README.md
@@ -13,6 +13,7 @@
         src="https://img.shields.io/github/discussions/vtempest/stock-prediction-agent" />
     </a>
     <!-- <a href="https://npmjs.org/package/stock-prediction-agent"><img src="https://img.shields.io/npm/v/stock-prediction-agent"/></a>    -->
+    <a href="https://stackblitz.com/github/OpenSourceAGI/ai-broker-investing-agent/tree/main/packages/investing"><img height="20px" src="https://developer.stackblitz.com/img/open_in_stackblitz.svg" alt="Open in StackBlitz" /></a>
     <a href="https://github.com/vtempest/stock-prediction-agent/pulse" alt="Activity">
         <img src="https://img.shields.io/github/commit-activity/m/vtempest/stock-prediction-agent" />
     </a>


### PR DESCRIPTION
Adds an **Open in StackBlitz** badge to every badge row in this repo.

StackBlitz installs from the manifest at the path it is handed, so each badge points at a package that boots on its own rather than at the monorepo root:

| Badge row | Opens |
| --- | --- |
| `README.md` | `packages/investing` — the package the root row's npm badges already advertise |
| `packages/investing/README.md` | `packages/investing` |
| `packages/ai-broker-api-client/README.md` | `packages/ai-broker-api-client` (Markdown-style badge, matching that row) |

No trading, risk or code changes — Markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kkb27RSQgLWvRWv1vcdJef

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kkb27RSQgLWvRWv1vcdJef)_