### PR TITLE
📝 docs(ai-broker-web): document features, env vars and deploy in the app README

### DIFF
--- a/apps/ai-broker-web/README.md
+++ b/apps/ai-broker-web/README.md
@@ -7,6 +7,20 @@ the D1 schema. This is the only workspace in the monorepo that ships.
 🚀 [Live app](https://autoinvestment.broker) ·
 🔌 [API](https://autoinvestment.broker/api/docs)
 
+## What it does
+
+| Area | Route | What you get |
+| --- | --- | --- |
+| Agent debate | `/debate`, `/stock/[symbol]` | Several LLM analyst agents argue a position — bull, bear, risk — and return a scored verdict with citations. |
+| Markets | `/markets`, `/stock/[symbol]` | Quotes, historical bars and charts from Alpaca and Finnhub, rendered with lightweight-charts. |
+| Portfolio | `/portfolio`, `/dashboard` | Positions, entry/exit signals from `packages/investing`, and paper or broker execution through Alpaca. |
+| Prediction markets | `/predict` | Cross-venue prices and arbitrage spreads from `packages/predictos` (Polymarket, Kalshi). |
+| Copy trading | `/leaders` | Leaderboards of tracked traders and their disclosed positions. |
+| Accounts | `/login`, `/legal` | better-auth sign-in (Google, email, SIWE wallet), Stripe subscriptions via the better-auth plugin, Didit KYC at `/api/kyc`. |
+| Admin | `/admin` | User and D1 controls, gated on `ADMIN_EMAILS`. |
+| Docs | `/docs` | This project's documentation, Fumadocs over `content/docs`. |
+| API | `/api/*` | 39 route groups, described by the OpenAPI spec that generates `packages/ai-broker-api-client`. |
+
 ## Stack
 
 | Layer | Choice |
@@ -26,9 +40,14 @@ From the repository root:
 
 ```bash
 bun install
+cp apps/ai-broker-web/.env.example apps/ai-broker-web/.env   # optional — see below
 bun run db:migrate:local   # create the local Miniflare D1
 bun run dev                # http://localhost:3000
 ```
+
+No keys are required to boot. An empty `.env` gives you the markets pages, the
+docs site and signed-out browsing; each key in
+[Environment variables](#environment-variables) switches one more feature on.
 
 The full walkthrough is in
 [Quick Start](https://docs.autoinvestment.broker/docs/getting-started).
@@ -78,15 +97,127 @@ first, or from this directory with `bun run <script>`.
 | `docs:generate:api` | Regenerates the API reference from the OpenAPI spec. |
 | `clean` | Removes `dist`, `.source`, `.turbo`, `.wrangler`, `node_modules`. |
 
-## Configuration
+## Environment variables
 
 Every variable is optional and validated in [`env.ts`](./env.ts), so a missing
-key disables one feature rather than failing the build. Put local values in
-`apps/ai-broker-web/.env`; put deployed secrets behind
-`wrangler secret put <NAME>`.
+key disables one feature rather than failing the build. Local values go in
+`apps/ai-broker-web/.env` (copy [`.env.example`](./.env.example)); deployed
+values go behind `wrangler secret put <NAME>`, except the plain
+`NEXT_PUBLIC_*` ones, which belong in `vars` in
+[`wrangler.jsonc`](./wrangler.jsonc) because the client bundle inlines them.
 
-The full table — Cloudflare, auth, admin, model providers, billing, email, cron,
-and app URLs — is in
+Nothing below is required to boot: `bun run db:migrate:local && bun run dev`
+gives you a working app with signed-out browsing, the docs site, and the
+markets pages. Add keys to switch features on.
+
+### App identity
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `NEXT_PUBLIC_APP_URL` | Absolute URLs in emails, OAuth callbacks, and the cron dispatcher's origin. | Your own deployed origin, e.g. `http://localhost:3000` in development. |
+| `NEXT_PUBLIC_APP_DOMAIN` | Cookie domain and canonical links. | Same as above. |
+| `NEXT_PUBLIC_APP_NAME` / `NEXT_PUBLIC_APP_EMAIL` | Branding in the UI and in outbound mail. | Your own values. |
+
+### Database — Cloudflare D1
+
+On Workers, D1 arrives as the `DB` binding declared in `wrangler.jsonc`; there
+is no connection string. These three are only read *outside* the Worker — by
+`drizzle-kit`, `db:studio`, and maintenance scripts.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `CLOUDFLARE_ACCOUNT_ID` | D1 over the REST API. | [Cloudflare dashboard](https://dash.cloudflare.com) → any zone → the Account ID in the right-hand sidebar. |
+| `CLOUDFLARE_D1_TOKEN` | The same, authenticated. Needs the **D1 Edit** permission. | [My Profile → API Tokens](https://dash.cloudflare.com/profile/api-tokens) → Create Token → Custom token. |
+| `CLOUDFLARE_DATABASE_ID` | Targets a database other than `ai-broker-db`. | `bunx wrangler d1 list`, or the ID already in `wrangler.jsonc`. |
+
+### Auth
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `BETTER_AUTH_SECRET` | Session signing. Without it, nobody can stay signed in. | Generate one: `openssl rand -base64 32`. See [better-auth installation](https://www.better-auth.com/docs/installation). |
+| `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` | The "Sign in with Google" button. | [Google Cloud Console → Credentials](https://console.cloud.google.com/apis/credentials) → OAuth client ID (Web application). Authorized redirect URI: `<APP_URL>/api/auth/callback/google`. |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | The same client ID, for the browser. | Same value as `GOOGLE_CLIENT_ID`. |
+| `ADMIN_EMAILS` (or `ADMIN_EMAIL`) | The `/admin` area, for the comma-separated addresses listed. With neither set, nobody is an admin. | Your own address. |
+
+SIWE wallet sign-in needs no keys — it verifies signatures in the Worker.
+
+### Email — Cloudflare Email Workers
+
+Delivery runs through the `SEND_EMAIL` binding, so there is no API key. Enable
+[Email Routing](https://developers.cloudflare.com/email-routing/) on the zone
+and verify the sender address there.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `EMAIL_FROM` | The From address on verification, password-reset, and invitation mail. | An address on a domain with Email Routing enabled. |
+
+### Model providers
+
+At least one is needed for the analyst agents and the debate view to answer.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `GROQ_API_KEY` | The default provider for the agent debate. | [console.groq.com/keys](https://console.groq.com/keys) |
+| `OPENAI_API_KEY` | OpenAI models. | [platform.openai.com/api-keys](https://platform.openai.com/api-keys) |
+| `GOOGLE_API_KEY` | Gemini models. | [Google AI Studio](https://aistudio.google.com/app/apikey) |
+| `ANTHROPIC_API_KEY` | Claude models. | [console.anthropic.com](https://console.anthropic.com/settings/keys) |
+| `XAI_API_KEY` | Grok models. | [console.x.ai](https://console.x.ai) |
+| `NEXT_PUBLIC_LLM_PROVIDER`, `NEXT_PUBLIC_GROQ_QUICK_THINK_MODEL`, `NEXT_PUBLIC_GROQ_DEEP_THINK_MODEL` | Which provider and model IDs the client picks by default. | Your own choice of model ID. |
+
+### Market data and brokerage
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `ALPACA_API_KEY` / `ALPACA_SECRET` (aliases: `APCA_API_KEY_ID` / `APCA_API_SECRET_KEY`) | Historical bars, live quote streaming, `/api/stocks/*`. | [Alpaca dashboard](https://app.alpaca.markets/paper/dashboard/overview) → API Keys. Paper keys work. |
+| `ALPACA_BASE_URL` | Points the data client somewhere other than `https://data.alpaca.markets`. | — |
+| `ALPACA_DATA_FEED` | `iex` (free) vs. `sip` (paid). | Alpaca plan. |
+| `ALPACA_BROKER_API_KEY` / `ALPACA_BROKER_SECRET_KEY` / `ALPACA_BROKER_BASE_URL` | The Broker API account endpoints — real accounts, not paper trading. | [Alpaca Broker API](https://alpaca.markets/broker) — requires an approved broker partner account. |
+| `FINNHUB_API_KEY` | Supplementary quotes and company data. | [finnhub.io/dashboard](https://finnhub.io/dashboard) |
+| `EODHD_API_KEY` | Delisted-symbol lookups. | [eodhd.com](https://eodhd.com/cp/dashboard) |
+
+> Broker credentials move real money. Keep production keys in
+> `wrangler secret put`, never in `.env`, and develop against Alpaca paper keys.
+
+### Billing — Stripe
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `STRIPE_SECRET_KEY` | Checkout and subscription management. | [dashboard.stripe.com/apikeys](https://dashboard.stripe.com/apikeys) |
+| `STRIPE_WEBHOOK_SECRET` | Verifying the Stripe callbacks better-auth handles under `/api/auth/stripe/webhook`. | [dashboard.stripe.com/webhooks](https://dashboard.stripe.com/webhooks) → your endpoint → Signing secret. Locally, `stripe listen --forward-to localhost:3000/api/auth/stripe/webhook` prints one. |
+
+### Identity verification — Didit
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `DIDIT_API_KEY` / `DIDIT_WORKFLOW_ID` | Starting a KYC session at `/api/kyc/start`. | [business.didit.me](https://business.didit.me) → API keys and the workflow you created. |
+| `DIDIT_WEBHOOK_SECRET` | Verifying KYC result callbacks. | The same dashboard, on the webhook. |
+
+### Scheduled triggers
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `CRON_SECRET` | The bearer token `worker/index.ts` sends to `/api/cron/*`, and that those routes require. | Generate one: `openssl rand -hex 32`. |
+
+The schedules live in `triggers.crons` in `wrangler.jsonc` and are mapped to
+routes in [`worker/index.ts`](./worker/index.ts) — currently
+`/api/cron/sync-markets` daily at 00:00 UTC and `/api/cron/refresh-quotes` at
+00:15 UTC. `sync-polymarket` and `sync-zulu` exist as routes but are not yet on
+a schedule — add them to both lists together.
+
+### Bot gate — Cloudflare Turnstile
+
+Optional. With both keys unset the gate never runs; set both to challenge a
+desktop browser's first HTML page view. Phones, crawlers, `/api/*`, assets and
+RSC fetches are never challenged.
+
+| Variable | Enables | Where to get it |
+| --- | --- | --- |
+| `TURNSTILE_SITE_KEY` / `TURNSTILE_SECRET_KEY` | The gate. | [Cloudflare dashboard](https://dash.cloudflare.com) → Turnstile → Add widget (Managed). |
+| `TURNSTILE_ENABLED` | `"false"` switches the gate off while keeping the keys. | — |
+| `TURNSTILE_TTL_SECONDS` | How long one pass lasts. Default 604800 (7 days), clamped to 5 minutes – 30 days. | — |
+| `TURNSTILE_COOKIE_DOMAIN` | Shares one pass across subdomains, e.g. `.autoinvestment.broker`. | — |
+
+The same table, with prose, is in
 [Configuration](https://docs.autoinvestment.broker/docs/getting-started/configuration).
 
 ## Cloudflare specifics
@@ -128,11 +259,43 @@ Vitest picks up `lib/**/__tests__/**/*.test.ts` and
 
 ## Deploying
 
+The target is Cloudflare Workers. Once, per account:
+
 ```bash
-bun run preview   # the production Worker, locally
+bunx wrangler login
+bunx wrangler d1 create ai-broker-db          # copy the id into wrangler.jsonc
+bun run db:migrate:remote                     # apply migrations/ to the remote D1
+```
+
+Then set the secrets. Only `BETTER_AUTH_SECRET` is needed for a usable deploy;
+add the rest as you turn features on:
+
+```bash
+for NAME in BETTER_AUTH_SECRET GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET \
+            CRON_SECRET GROQ_API_KEY ALPACA_API_KEY ALPACA_SECRET \
+            STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET; do
+  bunx wrangler secret put "$NAME"
+done
+```
+
+Public, non-secret values (`NEXT_PUBLIC_APP_URL`, `EMAIL_FROM`) go in `vars` in
+[`wrangler.jsonc`](./wrangler.jsonc) — the client bundle inlines them at build
+time, so a secret would not reach the browser anyway. `keep_vars: true` stops
+Wrangler from deleting variables you set in the dashboard.
+
+Also enable [Email Routing](https://developers.cloudflare.com/email-routing/)
+on the zone and verify `EMAIL_FROM` there, or every outbound message fails.
+
+Ship it:
+
+```bash
+bun run preview   # the production Worker, locally — do this first
 bun run deploy
 ```
 
-The full guide — D1 setup, secrets, Git-connected builds, custom domains, and
-rollbacks — is in
+`bun run deploy` runs `vinext-cloudflare deploy`, which builds and uploads the
+Worker, its assets, and the cron triggers together. Roll back from the
+dashboard under Workers → the Worker → Deployments.
+
+The full guide — Git-connected builds, custom domains, and rollbacks — is in
 [Deployment](https://docs.autoinvestment.broker/docs/deployment).


### PR DESCRIPTION
Part of a pass across all five repos making every `apps/*/README.md` describe what the app does, how to set it up and deploy it, and which environment variables it needs — with a link to the page that issues each one.

## What changed

`apps/ai-broker-web/README.md` was the only app README here. It pointed at the hosted docs for configuration and deployment, so a reader with the repo checked out could not tell which variables exist, what each one turns on, or where to obtain it.

- **Added a "What it does" table** mapping each route group (`/debate`, `/markets`, `/portfolio`, `/predict`, `/leaders`, `/admin`, `/docs`, `/api`) to its functionality and the package that owns it.
- **Replaced the Configuration stub with a full environment-variable reference**, grouped by concern — app identity, Cloudflare D1, auth, email, model providers, market data and brokerage, Stripe, Didit KYC, cron, Turnstile. Every row names what the variable enables and links to the page that issues it (Cloudflare API tokens, Google Cloud credentials, Groq/OpenAI/Anthropic/xAI consoles, Alpaca, Finnhub, EODHD, Stripe, Didit, Turnstile).
- **Expanded Deploying** into the actual first-deploy sequence: `wrangler login`, `d1 create`, remote migrations, the secret list, which values belong in `vars` instead of secrets and why, and the Email Routing prerequisite.

## Notes

- Every variable is optional and validated in `env.ts`, and the README now says so up front — an empty `.env` still boots the app.
- Route and endpoint references were checked against `app/` rather than assumed: the Stripe webhook is handled by the better-auth plugin under `/api/auth/stripe/webhook`, not a hand-written `/api/webhooks/stripe`, and there is no `/settings` route.
- `sync-polymarket` and `sync-zulu` exist as cron routes but are not on a schedule; the README says so rather than implying they run.

Documentation only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017kjFYq4o9xD5UQdZ16XctF

---
_Generated by [Claude Code](https://claude.ai/code/session_017kjFYq4o9xD5UQdZ16XctF)_